### PR TITLE
feat(dve): #209 -- non-LLM static verifier as second voice in N-of-M consensus

### DIFF
--- a/src/services/verification_envelope/config.py
+++ b/src/services/verification_envelope/config.py
@@ -41,6 +41,21 @@ class DVEConfig:
     # as soon as consensus is reached.
     exhaust_all_n_for_telemetry: bool = False
 
+    # ---------------------------------- LLM-independence (issue #209)
+
+    # When True, the consensus service runs a configured non-LLM
+    # static verifier on the selected centroid AND requires its
+    # agreement. Disagreement downgrades a CONVERGED outcome to
+    # DIVERGED so the orchestrator escalates to HITL. Default False
+    # for backward compatibility -- DAL A/B profiles flip this on.
+    require_non_llm_voice: bool = False
+
+    # When True, the static verifier runs even when
+    # ``require_non_llm_voice`` is False -- its verdict is recorded
+    # for audit but does not override the consensus outcome. Useful
+    # for telemetry / shadow-mode rollout. Default False.
+    static_verifier_shadow_mode: bool = False
+
     @classmethod
     def for_testing(cls) -> "DVEConfig":
         """Tight, fast config for unit tests."""

--- a/src/services/verification_envelope/consensus/__init__.py
+++ b/src/services/verification_envelope/consensus/__init__.py
@@ -12,12 +12,26 @@ from src.services.verification_envelope.consensus.consensus_service import (
 from src.services.verification_envelope.consensus.semantic_equivalence import (
     SemanticEquivalenceChecker,
 )
+from src.services.verification_envelope.consensus.static_verifier import (
+    ASTRuleVerifier,
+    StaticVerificationFinding,
+    StaticVerificationReport,
+    StaticVerificationVerdict,
+    StaticVerifierDispatcher,
+    StaticVerifierPort,
+)
 
 __all__ = [
     "ASTNormalizer",
+    "ASTRuleVerifier",
     "ConsensusDecision",
     "ConsensusService",
     "GeneratorFn",
     "SemanticEquivalenceChecker",
+    "StaticVerificationFinding",
+    "StaticVerificationReport",
+    "StaticVerificationVerdict",
+    "StaticVerifierDispatcher",
+    "StaticVerifierPort",
     "evaluate_convergence",
 ]

--- a/src/services/verification_envelope/consensus/consensus_service.py
+++ b/src/services/verification_envelope/consensus/consensus_service.py
@@ -35,11 +35,15 @@ from src.services.verification_envelope.consensus.semantic_equivalence import (
     SemanticEquivalenceChecker,
     _EmbeddingProvider,
 )
+from src.services.verification_envelope.consensus.static_verifier import (
+    StaticVerifierDispatcher,
+)
 from src.services.verification_envelope.contracts import (
     ASTCanonicalForm,
     ConsensusOutcome,
     ConsensusResult,
     EquivalenceCheck,
+    StaticVerificationSummary,
 )
 
 logger = logging.getLogger(__name__)
@@ -62,6 +66,7 @@ class ConsensusService:
         *,
         normalizer: ASTNormalizer | None = None,
         equivalence_checker: SemanticEquivalenceChecker | None = None,
+        static_verifier: StaticVerifierDispatcher | None = None,
     ) -> None:
         self._config = config
         self._generator = generator
@@ -71,6 +76,12 @@ class ConsensusService:
             cosine_threshold=config.embedding_cosine_threshold,
             enable_embedding_fallback=config.enable_embedding_fallback,
         )
+        # Non-LLM second voice (issue #209). When None, the consensus
+        # service behaves identically to its pre-#209 form. When the
+        # dispatcher is provided AND ``require_non_llm_voice`` is set,
+        # disagreement on the selected centroid downgrades CONVERGED
+        # to DIVERGED.
+        self._static_verifier = static_verifier
 
     async def generate_and_check(
         self, prompt: str, *, audit_id: str | None = None
@@ -104,22 +115,93 @@ class ConsensusService:
 
         similarity_matrix = tuple(tuple(c.similarity for c in row) for row in pairwise)
 
+        # Non-LLM second voice (issue #209). Run only when the verifier
+        # is configured AND either the policy requires it OR we are in
+        # shadow mode. Verdict is recorded in the result regardless; it
+        # only overrides the consensus outcome when require_non_llm_voice
+        # is set AND the verifier disagrees on the selected centroid.
+        outcome = decision.outcome
+        static_summary = StaticVerificationSummary()
+        should_run_static = (
+            self._static_verifier is not None
+            and not self._static_verifier.is_empty()
+            and (
+                self._config.require_non_llm_voice
+                or self._config.static_verifier_shadow_mode
+            )
+        )
+        if should_run_static and selected_output is not None:
+            report = self._static_verifier.verify(selected_output)
+            static_summary = StaticVerificationSummary(
+                enabled=True,
+                agreed_with_llm=report.agreed_with_llm,
+                verifier_count=report.verifier_count,
+                verifier_ids=self._static_verifier.verifier_ids,
+                blocking_finding_count=sum(
+                    1
+                    for f in report.aggregated_findings
+                    if f.severity.upper() in {"CRITICAL", "HIGH"}
+                ),
+                aggregate_latency_ms=report.aggregate_latency_ms,
+                rationale=(
+                    "static voice agreed"
+                    if report.agreed_with_llm
+                    else "static voice disagreed -- forcing DIVERGED"
+                ),
+            )
+            if (
+                self._config.require_non_llm_voice
+                and report.disagreed_with_llm
+                and outcome == ConsensusOutcome.CONVERGED
+            ):
+                logger.warning(
+                    "consensus %s overridden CONVERGED->DIVERGED by static voice "
+                    "(%d blocking findings across %d verifiers)",
+                    record_id,
+                    static_summary.blocking_finding_count,
+                    static_summary.verifier_count,
+                )
+                outcome = ConsensusOutcome.DIVERGED
+                selected_output = None
+        elif (
+            self._config.require_non_llm_voice
+            and selected_output is not None
+            and (self._static_verifier is None or self._static_verifier.is_empty())
+        ):
+            # Policy requires a non-LLM voice but none is configured.
+            # Fail closed: downgrade to DIVERGED and surface in audit.
+            logger.warning(
+                "consensus %s requires non-LLM voice but no verifier configured; "
+                "downgrading CONVERGED->DIVERGED",
+                record_id,
+            )
+            outcome = ConsensusOutcome.DIVERGED
+            selected_output = None
+            static_summary = StaticVerificationSummary(
+                enabled=False,
+                agreed_with_llm=False,
+                rationale="policy requires non-LLM voice; none configured (fail-closed)",
+            )
+
         latency_ms = (time.time() - start) * 1000.0
         logger.info(
             "consensus %s outcome=%s n=%d m_required=%d converged=%d "
-            "selection=%s rate=%.2f latency_ms=%.0f",
+            "selection=%s rate=%.2f latency_ms=%.0f "
+            "static_voice=%s static_agreed=%s",
             record_id,
-            decision.outcome.value,
+            outcome.value,
             n,
             m,
             len(decision.converged_indices),
             decision.selection_method,
             convergence_rate,
             latency_ms,
+            static_summary.enabled,
+            static_summary.agreed_with_llm,
         )
 
         return ConsensusResult(
-            outcome=decision.outcome,
+            outcome=outcome,
             n_generated=n,
             m_required=m,
             m_converged=len(decision.converged_indices),
@@ -130,6 +212,7 @@ class ConsensusService:
             convergence_rate=convergence_rate,
             audit_record_id=record_id,
             computed_at=datetime.now(timezone.utc),
+            static_verification=static_summary,
         )
 
     # ------------------------------------------------------------ helpers

--- a/src/services/verification_envelope/consensus/static_verifier.py
+++ b/src/services/verification_envelope/consensus/static_verifier.py
@@ -1,0 +1,337 @@
+"""Project Aura - Non-LLM Static Verifier Track (issue #209).
+
+Closes the LLM-independence gap in ADR-085's N-of-M consensus. The
+existing consensus pillar runs N LLM generations and compares them
+against each other -- but the verdict still comes from one model
+family (Bedrock / Claude). A coordinated failure in that family is
+not detectable by intra-family consensus.
+
+This module adds an **independent second voice** that does not call
+an LLM. It examines the selected centroid output and either confirms
+the consensus or flags a disagreement that forces HITL escalation.
+
+The Port is intentionally small so future implementations (semgrep,
+bandit, custom CWE-rule packs, Z3 lite-mode) can drop in without
+touching the consensus service.
+
+Implements issue #209.
+
+Author: Project Aura Team
+Created: 2026-05-22
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import time
+from dataclasses import dataclass
+from typing import Iterable, Protocol
+
+# ---------------------------------------------------------------- contracts
+
+
+@dataclass(frozen=True)
+class StaticVerificationFinding:
+    """A single finding produced by a static verifier."""
+
+    rule_id: str  # e.g. "AURA-SV-001"
+    severity: str  # CRITICAL / HIGH / MEDIUM / LOW / INFO
+    message: str
+    cwe_id: str = ""  # optional CWE attribution
+    line_hint: int = 0  # 1-indexed; 0 if unknown
+
+
+@dataclass(frozen=True)
+class StaticVerificationVerdict:
+    """Result of one static-verifier track examining one candidate."""
+
+    verifier_id: str  # stable identifier for the verifier
+    passed: bool  # True iff no CRITICAL / HIGH findings
+    findings: tuple[StaticVerificationFinding, ...] = ()
+    rationale: str = ""
+    latency_ms: float = 0.0
+
+    @property
+    def has_blocking_finding(self) -> bool:
+        return any(f.severity.upper() in {"CRITICAL", "HIGH"} for f in self.findings)
+
+
+@dataclass(frozen=True)
+class StaticVerificationReport:
+    """Aggregate report across one or more static verifiers."""
+
+    verdicts: tuple[StaticVerificationVerdict, ...] = ()
+    agreed_with_llm: bool = True  # True iff all verdicts passed
+    aggregated_findings: tuple[StaticVerificationFinding, ...] = ()
+    verifier_count: int = 0
+    aggregate_latency_ms: float = 0.0
+
+    @property
+    def disagreed_with_llm(self) -> bool:
+        return not self.agreed_with_llm
+
+    def to_audit_dict(self) -> dict:
+        return {
+            "verifier_count": self.verifier_count,
+            "agreed_with_llm": self.agreed_with_llm,
+            "verdicts": [
+                {
+                    "verifier_id": v.verifier_id,
+                    "passed": v.passed,
+                    "finding_count": len(v.findings),
+                    "latency_ms": v.latency_ms,
+                }
+                for v in self.verdicts
+            ],
+            "aggregate_latency_ms": self.aggregate_latency_ms,
+        }
+
+
+# ---------------------------------------------------------------- Port
+
+
+class StaticVerifierPort(Protocol):
+    """Non-LLM verifier that examines one candidate source string.
+
+    Implementations must be **deterministic** (same input -> same
+    verdict) and **side-effect-free**. They run inside the consensus
+    service hot path; latency budget is < 200ms per verifier.
+    """
+
+    verifier_id: str
+
+    def verify(self, source: str) -> StaticVerificationVerdict:
+        """Examine ``source`` and return a verdict."""
+
+
+# ---------------------------------------------------------------- dispatcher
+
+
+class StaticVerifierDispatcher:
+    """Runs one or more static verifiers and aggregates their verdicts.
+
+    The dispatcher is deliberately synchronous: each verifier is
+    CPU-bound and small, and serialising them keeps the audit trail
+    deterministic. Tests can pass a single verifier; production wires
+    several.
+    """
+
+    def __init__(self, verifiers: Iterable[StaticVerifierPort]) -> None:
+        self._verifiers: tuple[StaticVerifierPort, ...] = tuple(verifiers)
+        seen: set[str] = set()
+        for v in self._verifiers:
+            if v.verifier_id in seen:
+                raise ValueError(
+                    f"Duplicate verifier_id in dispatcher: {v.verifier_id!r}"
+                )
+            seen.add(v.verifier_id)
+
+    @property
+    def verifier_ids(self) -> tuple[str, ...]:
+        return tuple(v.verifier_id for v in self._verifiers)
+
+    def is_empty(self) -> bool:
+        return len(self._verifiers) == 0
+
+    def verify(self, source: str) -> StaticVerificationReport:
+        """Run every verifier on ``source``; aggregate the verdicts."""
+        start = time.time()
+        verdicts: list[StaticVerificationVerdict] = []
+        aggregated: list[StaticVerificationFinding] = []
+        all_passed = True
+        for verifier in self._verifiers:
+            verdict = verifier.verify(source)
+            verdicts.append(verdict)
+            aggregated.extend(verdict.findings)
+            if not verdict.passed:
+                all_passed = False
+        return StaticVerificationReport(
+            verdicts=tuple(verdicts),
+            agreed_with_llm=all_passed,
+            aggregated_findings=tuple(aggregated),
+            verifier_count=len(self._verifiers),
+            aggregate_latency_ms=(time.time() - start) * 1000.0,
+        )
+
+
+# ---------------------------------------------------------------- concrete
+
+
+# Rule pack for the initial AST-rule verifier. Each rule is intentionally
+# *narrow* -- this verifier exists to provide an independent second
+# voice on common dangerous patterns, not to replace the dedicated
+# vulnerability scanner. Findings here trigger HITL escalation, not
+# auto-rejection, because the LLM consensus may have a legitimate
+# reason to use these patterns (test fixtures, deliberate examples).
+_DANGEROUS_BUILTINS: frozenset[str] = frozenset({"eval", "exec", "compile"})
+_DANGEROUS_OS_CALLS: frozenset[str] = frozenset({"system", "popen", "spawn"})
+_HARDCODED_SECRET_RE: re.Pattern[str] = re.compile(
+    r"""(?xi)
+    (?P<kind>password|passwd|secret|api[_-]?key|access[_-]?token|
+        bearer|private[_-]?key|aws[_-]?secret)
+    \s*[=:]\s*
+    ['"]
+    (?P<value>[A-Za-z0-9+/=_\-]{12,})
+    ['"]
+    """,
+)
+_SHELL_INJECTION_RE: re.Pattern[str] = re.compile(r"shell\s*=\s*True", re.IGNORECASE)
+
+
+class _DangerousCallVisitor(ast.NodeVisitor):
+    """Collects line numbers of calls to dangerous builtins / os APIs."""
+
+    def __init__(self) -> None:
+        self.dangerous_builtin_calls: list[tuple[str, int]] = []
+        self.dangerous_os_calls: list[tuple[str, int]] = []
+        self.pickle_loads_calls: list[int] = []
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 (ast convention)
+        # eval / exec / compile
+        if isinstance(node.func, ast.Name) and node.func.id in _DANGEROUS_BUILTINS:
+            self.dangerous_builtin_calls.append((node.func.id, node.lineno))
+        # os.system / os.popen / subprocess.* with shell=True caught separately
+        elif isinstance(node.func, ast.Attribute):
+            if (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "os"
+                and node.func.attr in _DANGEROUS_OS_CALLS
+            ):
+                self.dangerous_os_calls.append((node.func.attr, node.lineno))
+            elif (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "pickle"
+                and node.func.attr in {"loads", "load"}
+            ):
+                self.pickle_loads_calls.append(node.lineno)
+        self.generic_visit(node)
+
+
+class ASTRuleVerifier:
+    """Initial non-LLM static verifier.
+
+    Performs a deterministic AST + regex scan for a narrow set of
+    high-signal patterns:
+
+    - eval / exec / compile (CWE-94 Code Injection)
+    - os.system / os.popen / os.spawn (CWE-78 OS Command Injection)
+    - subprocess shell=True (CWE-78)
+    - pickle.loads / pickle.load on untrusted data (CWE-502)
+    - hardcoded credential literals (CWE-798)
+
+    Each match becomes a HIGH-severity finding. The dispatcher treats
+    HIGH findings as 'disagreed with LLM' and the consensus service
+    downgrades the verdict accordingly. Source files that fail to
+    parse emit a single INFO finding and the verifier returns
+    ``passed=True`` (the LLM-side AST normaliser already rejects
+    unparseable output, so this would be a redundant failure).
+    """
+
+    verifier_id: str = "ast-rule-v1"
+
+    def verify(self, source: str) -> StaticVerificationVerdict:
+        start = time.time()
+        findings: list[StaticVerificationFinding] = []
+
+        # AST-based checks.
+        try:
+            tree = ast.parse(source)
+        except SyntaxError as exc:
+            return StaticVerificationVerdict(
+                verifier_id=self.verifier_id,
+                passed=True,  # AST-normaliser will reject; we don't double-fail
+                findings=(
+                    StaticVerificationFinding(
+                        rule_id="AURA-SV-PARSE",
+                        severity="INFO",
+                        message=f"Source unparseable; deferred to AST normaliser: {exc}",
+                    ),
+                ),
+                rationale="parse-fail",
+                latency_ms=(time.time() - start) * 1000.0,
+            )
+
+        visitor = _DangerousCallVisitor()
+        visitor.visit(tree)
+        for name, lineno in visitor.dangerous_builtin_calls:
+            findings.append(
+                StaticVerificationFinding(
+                    rule_id="AURA-SV-001",
+                    severity="HIGH",
+                    message=f"Dangerous builtin call: {name}()",
+                    cwe_id="CWE-94",
+                    line_hint=lineno,
+                )
+            )
+        for name, lineno in visitor.dangerous_os_calls:
+            findings.append(
+                StaticVerificationFinding(
+                    rule_id="AURA-SV-002",
+                    severity="HIGH",
+                    message=f"Shell-equivalent OS call: os.{name}()",
+                    cwe_id="CWE-78",
+                    line_hint=lineno,
+                )
+            )
+        for lineno in visitor.pickle_loads_calls:
+            findings.append(
+                StaticVerificationFinding(
+                    rule_id="AURA-SV-003",
+                    severity="HIGH",
+                    message="Deserialisation of untrusted data via pickle",
+                    cwe_id="CWE-502",
+                    line_hint=lineno,
+                )
+            )
+
+        # Regex-based checks (run on the raw source for shell=True and
+        # hardcoded secrets -- AST is overkill for these).
+        for match in _SHELL_INJECTION_RE.finditer(source):
+            lineno = source[: match.start()].count("\n") + 1
+            findings.append(
+                StaticVerificationFinding(
+                    rule_id="AURA-SV-004",
+                    severity="HIGH",
+                    message="subprocess invocation with shell=True",
+                    cwe_id="CWE-78",
+                    line_hint=lineno,
+                )
+            )
+        for match in _HARDCODED_SECRET_RE.finditer(source):
+            lineno = source[: match.start()].count("\n") + 1
+            findings.append(
+                StaticVerificationFinding(
+                    rule_id="AURA-SV-005",
+                    severity="HIGH",
+                    message=(
+                        f"Hardcoded {match.group('kind')!s} literal "
+                        f"(len={len(match.group('value'))})"
+                    ),
+                    cwe_id="CWE-798",
+                    line_hint=lineno,
+                )
+            )
+
+        passed = not any(f.severity.upper() in {"CRITICAL", "HIGH"} for f in findings)
+        return StaticVerificationVerdict(
+            verifier_id=self.verifier_id,
+            passed=passed,
+            findings=tuple(findings),
+            rationale=(
+                "no blocking findings"
+                if passed
+                else f"{len(findings)} blocking findings"
+            ),
+            latency_ms=(time.time() - start) * 1000.0,
+        )
+
+
+__all__ = [
+    "ASTRuleVerifier",
+    "StaticVerificationFinding",
+    "StaticVerificationReport",
+    "StaticVerificationVerdict",
+    "StaticVerifierDispatcher",
+    "StaticVerifierPort",
+]

--- a/src/services/verification_envelope/contracts.py
+++ b/src/services/verification_envelope/contracts.py
@@ -77,6 +77,37 @@ class EquivalenceCheck:
 
 
 @dataclass(frozen=True)
+class StaticVerificationSummary:
+    """Audit-trail summary of the non-LLM second voice (issue #209).
+
+    Embedded in :class:`ConsensusResult` so a single audit record
+    captures both the LLM-consensus decision and the independent
+    static verifier's verdict on the selected centroid. Defaults
+    represent the "no static verifier configured" state -- old
+    consumers can ignore this field without behaviour change.
+    """
+
+    enabled: bool = False
+    agreed_with_llm: bool = True
+    verifier_count: int = 0
+    verifier_ids: tuple[str, ...] = ()
+    blocking_finding_count: int = 0
+    aggregate_latency_ms: float = 0.0
+    rationale: str = ""
+
+    def to_audit_dict(self) -> dict:
+        return {
+            "enabled": self.enabled,
+            "agreed_with_llm": self.agreed_with_llm,
+            "verifier_count": self.verifier_count,
+            "verifier_ids": list(self.verifier_ids),
+            "blocking_finding_count": self.blocking_finding_count,
+            "aggregate_latency_ms": self.aggregate_latency_ms,
+            "rationale": self.rationale,
+        }
+
+
+@dataclass(frozen=True)
 class ConsensusResult:
     """Result of an N-of-M consensus generation round.
 
@@ -86,6 +117,12 @@ class ConsensusResult:
     and the pairwise similarity matrix attached. ``PARTIAL`` is
     intermediate (used by callers that want to surface partial
     convergence without escalating immediately).
+
+    ``static_verification`` (added per issue #209) carries the
+    independent non-LLM second voice's verdict on the selected
+    centroid. When the policy ``require_non_llm_voice`` is enabled
+    and the static voice disagrees, ``outcome`` is overridden to
+    ``DIVERGED`` and the orchestrator escalates to HITL.
     """
 
     outcome: ConsensusOutcome
@@ -99,6 +136,9 @@ class ConsensusResult:
     convergence_rate: float
     audit_record_id: str
     computed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    static_verification: StaticVerificationSummary = field(
+        default_factory=StaticVerificationSummary
+    )
 
     @property
     def needs_hitl(self) -> bool:
@@ -117,6 +157,7 @@ class ConsensusResult:
             "canonical_hashes": [c.canonical_hash for c in self.canonical_forms],
             "pairwise_similarities": [list(row) for row in self.pairwise_similarities],
             "computed_at": self.computed_at.isoformat(),
+            "static_verification": self.static_verification.to_audit_dict(),
         }
 
 

--- a/tests/services/verification_envelope/consensus/test_static_verifier.py
+++ b/tests/services/verification_envelope/consensus/test_static_verifier.py
@@ -1,0 +1,297 @@
+"""Tests for the non-LLM static verifier track (issue #209)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from src.services.verification_envelope.config import DVEConfig
+from src.services.verification_envelope.consensus.consensus_service import (
+    ConsensusService,
+)
+from src.services.verification_envelope.consensus.static_verifier import (
+    ASTRuleVerifier,
+    StaticVerificationFinding,
+    StaticVerificationVerdict,
+    StaticVerifierDispatcher,
+)
+from src.services.verification_envelope.contracts import ConsensusOutcome
+
+# =============================================================================
+# ASTRuleVerifier -- rule pack
+# =============================================================================
+
+
+class TestASTRuleVerifier:
+    def test_clean_code_passes(self):
+        verifier = ASTRuleVerifier()
+        verdict = verifier.verify("def add(a: int, b: int) -> int:\n    return a + b\n")
+        assert verdict.passed is True
+        assert verdict.findings == ()
+
+    def test_eval_call_flagged_as_high(self):
+        verifier = ASTRuleVerifier()
+        verdict = verifier.verify("def run(s: str):\n    return eval(s)\n")
+        assert verdict.passed is False
+        ids = [f.rule_id for f in verdict.findings]
+        assert "AURA-SV-001" in ids
+        assert any(f.cwe_id == "CWE-94" for f in verdict.findings)
+
+    def test_os_system_flagged(self):
+        verifier = ASTRuleVerifier()
+        verdict = verifier.verify("import os\n\ndef run(s: str):\n    os.system(s)\n")
+        assert verdict.passed is False
+        assert any(f.rule_id == "AURA-SV-002" for f in verdict.findings)
+        assert any(f.cwe_id == "CWE-78" for f in verdict.findings)
+
+    def test_pickle_loads_flagged(self):
+        verifier = ASTRuleVerifier()
+        verdict = verifier.verify(
+            "import pickle\n\ndef d(b: bytes):\n    return pickle.loads(b)\n"
+        )
+        assert verdict.passed is False
+        assert any(f.rule_id == "AURA-SV-003" for f in verdict.findings)
+        assert any(f.cwe_id == "CWE-502" for f in verdict.findings)
+
+    def test_shell_true_flagged(self):
+        verifier = ASTRuleVerifier()
+        verdict = verifier.verify(
+            "import subprocess\n"
+            "def r(cmd: str):\n"
+            "    subprocess.run(cmd, shell=True)\n"
+        )
+        assert verdict.passed is False
+        assert any(f.rule_id == "AURA-SV-004" for f in verdict.findings)
+
+    def test_hardcoded_secret_flagged(self):
+        verifier = ASTRuleVerifier()
+        verdict = verifier.verify(
+            'API_KEY = "sk-prod-abcdef0123456789"\n'
+            "def get_key():\n    return API_KEY\n"
+        )
+        assert verdict.passed is False
+        assert any(f.rule_id == "AURA-SV-005" for f in verdict.findings)
+        assert any(f.cwe_id == "CWE-798" for f in verdict.findings)
+
+    def test_short_string_assignments_are_not_secrets(self):
+        verifier = ASTRuleVerifier()
+        verdict = verifier.verify('foo = "bar"\n')
+        assert verdict.passed is True
+
+    def test_unparseable_source_defers_to_normaliser(self):
+        verifier = ASTRuleVerifier()
+        verdict = verifier.verify("def broken(:")
+        # Parse-fail does not double-fail; AST normaliser handles it.
+        assert verdict.passed is True
+        assert verdict.findings[0].rule_id == "AURA-SV-PARSE"
+
+    def test_multiple_findings_aggregated(self):
+        verifier = ASTRuleVerifier()
+        verdict = verifier.verify(
+            "import os, pickle\n"
+            'API_KEY = "sk-prod-abcdef0123456789"\n'
+            "def run(s):\n"
+            "    eval(s)\n"
+            "    os.system(s)\n"
+            "    pickle.loads(b'')\n"
+        )
+        assert verdict.passed is False
+        rule_ids = {f.rule_id for f in verdict.findings}
+        assert {"AURA-SV-001", "AURA-SV-002", "AURA-SV-003", "AURA-SV-005"} <= rule_ids
+
+
+# =============================================================================
+# Dispatcher
+# =============================================================================
+
+
+@dataclass
+class _AlwaysPassVerifier:
+    verifier_id: str = "always-pass"
+
+    def verify(self, source: str) -> StaticVerificationVerdict:
+        return StaticVerificationVerdict(verifier_id=self.verifier_id, passed=True)
+
+
+@dataclass
+class _AlwaysFailVerifier:
+    verifier_id: str = "always-fail"
+
+    def verify(self, source: str) -> StaticVerificationVerdict:
+        return StaticVerificationVerdict(
+            verifier_id=self.verifier_id,
+            passed=False,
+            findings=(
+                StaticVerificationFinding(
+                    rule_id="TEST-001",
+                    severity="HIGH",
+                    message="forced disagreement",
+                ),
+            ),
+        )
+
+
+class TestDispatcher:
+    def test_empty_dispatcher_is_empty(self):
+        d = StaticVerifierDispatcher(verifiers=[])
+        assert d.is_empty()
+        report = d.verify("anything")
+        assert report.verifier_count == 0
+        assert report.agreed_with_llm is True
+
+    def test_all_pass_agrees(self):
+        d = StaticVerifierDispatcher([_AlwaysPassVerifier(), ASTRuleVerifier()])
+        report = d.verify("def f(): return 1\n")
+        assert report.agreed_with_llm is True
+        assert report.verifier_count == 2
+
+    def test_any_fail_disagrees(self):
+        d = StaticVerifierDispatcher([_AlwaysPassVerifier(), _AlwaysFailVerifier()])
+        report = d.verify("def f(): return 1\n")
+        assert report.agreed_with_llm is False
+        assert report.disagreed_with_llm is True
+        assert any(v.passed is False for v in report.verdicts)
+
+    def test_duplicate_verifier_id_rejected(self):
+        with pytest.raises(ValueError):
+            StaticVerifierDispatcher([_AlwaysPassVerifier(), _AlwaysPassVerifier()])
+
+
+# =============================================================================
+# ConsensusService integration (the actual issue #209 closure)
+# =============================================================================
+
+
+def _three_identical_outputs() -> list[str]:
+    return [
+        "def add(a: int, b: int) -> int:\n    return a + b\n",
+        "def add(a: int, b: int) -> int:\n    return a + b\n",
+        "def add(a: int, b: int) -> int:\n    return a + b\n",
+    ]
+
+
+def _three_unsafe_outputs() -> list[str]:
+    """Three LLM runs all converge on dangerous code (eval)."""
+    return [
+        "def run(s: str):\n    return eval(s)\n",
+        "def run(s: str):\n    return eval(s)\n",
+        "def run(s: str):\n    return eval(s)\n",
+    ]
+
+
+def _make_generator(outputs: list[str]):
+    """Builds an async generator returning outputs[0], [1], [2] in order."""
+    iter_outputs = iter(outputs)
+
+    async def _gen(prompt: str) -> str:
+        return next(iter_outputs)
+
+    return _gen
+
+
+class TestConsensusServiceIntegration:
+    @pytest.mark.asyncio
+    async def test_no_static_verifier_behaves_like_pre_209(self):
+        cfg = DVEConfig.for_testing()
+        svc = ConsensusService(
+            config=cfg, generator=_make_generator(_three_identical_outputs())
+        )
+        result = await svc.generate_and_check("dummy prompt")
+        assert result.outcome == ConsensusOutcome.CONVERGED
+        assert result.static_verification.enabled is False
+        assert result.static_verification.agreed_with_llm is True
+
+    @pytest.mark.asyncio
+    async def test_static_voice_disagreement_forces_diverged_at_dal_a(self):
+        # Policy: require_non_llm_voice=True (DAL A/B). Three runs converge
+        # on eval()-laden code; static voice flags it as unsafe; outcome is
+        # downgraded to DIVERGED so the orchestrator escalates to HITL.
+        cfg = DVEConfig.for_testing()
+        from dataclasses import replace
+
+        cfg = replace(cfg, require_non_llm_voice=True)
+        svc = ConsensusService(
+            config=cfg,
+            generator=_make_generator(_three_unsafe_outputs()),
+            static_verifier=StaticVerifierDispatcher([ASTRuleVerifier()]),
+        )
+        result = await svc.generate_and_check("dummy prompt")
+        assert result.outcome == ConsensusOutcome.DIVERGED
+        assert result.selected_output is None  # forced HITL
+        assert result.static_verification.enabled is True
+        assert result.static_verification.agreed_with_llm is False
+        assert result.static_verification.blocking_finding_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_static_voice_agreement_keeps_converged(self):
+        cfg = DVEConfig.for_testing()
+        from dataclasses import replace
+
+        cfg = replace(cfg, require_non_llm_voice=True)
+        svc = ConsensusService(
+            config=cfg,
+            generator=_make_generator(_three_identical_outputs()),
+            static_verifier=StaticVerifierDispatcher([ASTRuleVerifier()]),
+        )
+        result = await svc.generate_and_check("dummy prompt")
+        assert result.outcome == ConsensusOutcome.CONVERGED
+        assert result.selected_output is not None
+        assert result.static_verification.enabled is True
+        assert result.static_verification.agreed_with_llm is True
+
+    @pytest.mark.asyncio
+    async def test_shadow_mode_records_but_does_not_override(self):
+        # Shadow mode: verifier runs and disagrees, but consensus outcome
+        # is NOT overridden -- only audit-trail captures the disagreement.
+        cfg = DVEConfig.for_testing()
+        from dataclasses import replace
+
+        cfg = replace(
+            cfg, require_non_llm_voice=False, static_verifier_shadow_mode=True
+        )
+        svc = ConsensusService(
+            config=cfg,
+            generator=_make_generator(_three_unsafe_outputs()),
+            static_verifier=StaticVerifierDispatcher([ASTRuleVerifier()]),
+        )
+        result = await svc.generate_and_check("dummy prompt")
+        assert result.outcome == ConsensusOutcome.CONVERGED
+        assert result.selected_output is not None
+        assert result.static_verification.enabled is True
+        assert result.static_verification.agreed_with_llm is False
+        assert result.static_verification.blocking_finding_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_dal_a_policy_with_no_verifier_fails_closed(self):
+        # require_non_llm_voice=True but no dispatcher configured ->
+        # fail-closed: downgrade to DIVERGED rather than silently accept.
+        cfg = DVEConfig.for_testing()
+        from dataclasses import replace
+
+        cfg = replace(cfg, require_non_llm_voice=True)
+        svc = ConsensusService(
+            config=cfg, generator=_make_generator(_three_identical_outputs())
+        )
+        result = await svc.generate_and_check("dummy prompt")
+        assert result.outcome == ConsensusOutcome.DIVERGED
+        assert result.selected_output is None
+        assert result.static_verification.enabled is False
+        assert "fail-closed" in result.static_verification.rationale
+
+    @pytest.mark.asyncio
+    async def test_audit_dict_includes_static_verification(self):
+        cfg = DVEConfig.for_testing()
+        from dataclasses import replace
+
+        cfg = replace(cfg, require_non_llm_voice=True)
+        svc = ConsensusService(
+            config=cfg,
+            generator=_make_generator(_three_identical_outputs()),
+            static_verifier=StaticVerifierDispatcher([ASTRuleVerifier()]),
+        )
+        result = await svc.generate_and_check("dummy prompt")
+        audit = result.to_audit_dict()
+        assert "static_verification" in audit
+        assert audit["static_verification"]["enabled"] is True
+        assert audit["static_verification"]["verifier_count"] == 1


### PR DESCRIPTION
## Summary

Closes #209. ADR-085's N-of-M consensus runs three LLM generations and compares them -- but until now the verdict still came from one model family (Bedrock / Claude). A coordinated failure in that family was undetectable. This PR adds an independent non-LLM **second voice** that examines the selected centroid and can override CONVERGED to DIVERGED, forcing HITL escalation.

## What ships

- New module \`src/services/verification_envelope/consensus/static_verifier.py\` with \`StaticVerifierPort\` Protocol, \`StaticVerifierDispatcher\`, and an initial \`ASTRuleVerifier\` covering eval/exec/compile (CWE-94), os.system/popen/spawn (CWE-78), pickle.loads (CWE-502), subprocess shell=True (CWE-78), and hardcoded credential literals (CWE-798).
- \`ConsensusService\` accepts an optional \`StaticVerifierDispatcher\` and consults it after the M-of-N decision when policy or shadow mode is enabled.
- Two new \`DVEConfig\` flags: \`require_non_llm_voice\` (overrides on disagreement; fail-closed if no verifier configured) and \`static_verifier_shadow_mode\` (audit-only).
- \`ConsensusResult\` embeds a \`StaticVerificationSummary\` for the audit dict.

## Honest scope

- The \`ASTRuleVerifier\` is **narrow on purpose** -- the dedicated vulnerability scanner remains the breadth tool. This verifier exists to be a high-signal *independent voice* on the most dangerous patterns. Future implementations (semgrep, bandit, custom CWE packs, Z3 lite-mode) drop in via the same Port.
- DAL A/B policy profiles do not flip \`require_non_llm_voice=True\` yet -- that wiring (in \`verification_envelope/policies/\`) is a small follow-up so dial-a-DAL stays a single seam.
- ADR-085 will get an addendum and a PROJECT_STATUS row bump in a separate commit once DAL profile wiring lands.

## Test plan

- [x] 19 new tests in \`tests/services/verification_envelope/consensus/test_static_verifier.py\` covering: each rule in the AST verifier (positive + negative), dispatcher behaviour, duplicate-id rejection, the no-verifier baseline (pre-#209 behaviour preserved), DAL-A override on disagreement, DAL-A agreement keeps CONVERGED, shadow mode records without overriding, fail-closed when policy requires a voice and none is configured, audit-dict shape.
- [x] 210 existing DVE tests still pass.
- [x] Lint clean (black, flake8, isort, bandit).
- [ ] CI green.

## Related

- ADR-085 (Deterministic Verification Envelope)
- ADR-032 (HITL) -- HITL remains the final safety net
- ADR-088 (Continuous Model Assurance) -- frozen reference oracle benefits from the same static-only regression suite (separate PR)
- Issues #210 #211 #212 -- companion AI-vuln gaps tracked separately