### PR TITLE
feat(runtime-security): #211 -- adversarial agent detection layer

### DIFF
--- a/src/services/runtime_security/adversarial_detector/__init__.py
+++ b/src/services/runtime_security/adversarial_detector/__init__.py
@@ -1,0 +1,49 @@
+"""Adversarial agent detection layer (issue #211).
+
+Signature-based detectors that layer on top of the behavioural
+baseline + drift detection in ADR-083. Baselines catch agents whose
+behaviour *changes* after compromise. These detectors catch agents
+that were *designed from the start* to look normal -- their baseline
+itself is adversarial.
+
+Detectors emit ``AdversarialFinding`` records with MITRE ATT&CK IDs
+that the existing runtime-security event router consumes.
+"""
+
+from src.services.runtime_security.adversarial_detector.collusion import (
+    CrossAgentCollusionDetector,
+    TTPRule,
+)
+from src.services.runtime_security.adversarial_detector.contracts import (
+    AdversarialFinding,
+    AdversarialFindingSeverity,
+    AgentActionEvent,
+    DelegationEdge,
+)
+from src.services.runtime_security.adversarial_detector.delegation_shape import (
+    DelegationGraphShapeDetector,
+)
+from src.services.runtime_security.adversarial_detector.dormancy_burst import (
+    DormancyThenBurstDetector,
+)
+from src.services.runtime_security.adversarial_detector.port import (
+    AdversarialDetectorDispatcher,
+    AdversarialDetectorPort,
+)
+from src.services.runtime_security.adversarial_detector.slow_roll import (
+    SlowRollCapabilityCreepDetector,
+)
+
+__all__ = [
+    "AdversarialDetectorDispatcher",
+    "AdversarialDetectorPort",
+    "AdversarialFinding",
+    "AdversarialFindingSeverity",
+    "AgentActionEvent",
+    "CrossAgentCollusionDetector",
+    "DelegationEdge",
+    "DelegationGraphShapeDetector",
+    "DormancyThenBurstDetector",
+    "SlowRollCapabilityCreepDetector",
+    "TTPRule",
+]

--- a/src/services/runtime_security/adversarial_detector/collusion.py
+++ b/src/services/runtime_security/adversarial_detector/collusion.py
@@ -1,0 +1,176 @@
+"""Cross-agent collusion detector (issue #211).
+
+Detects two-or-more-agent coordinated action sequences where each
+individual action looks fine but the *combination* completes a
+known adversarial TTP (Tactics, Techniques, Procedures).
+
+The detector takes a small declarative ``TTPRule`` registry and
+scans the event stream for ordered action sequences that match a
+rule's pattern across distinct agents within a time window.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Sequence
+
+from src.services.runtime_security.adversarial_detector.contracts import (
+    AdversarialFinding,
+    AdversarialFindingSeverity,
+    AgentActionEvent,
+    DelegationEdge,
+)
+
+
+@dataclass(frozen=True)
+class TTPRule:
+    """Declarative rule for a multi-agent TTP.
+
+    A rule fires when the named ``action_sequence`` is observed in
+    order across **distinct** agents inside the ``window_seconds``
+    time bound. Action names match by exact string equality against
+    ``AgentActionEvent.action_name``.
+    """
+
+    rule_id: str  # e.g. "credential-shuck-and-pivot"
+    description: str
+    action_sequence: tuple[str, ...]  # ordered
+    window_seconds: float
+    mitre_attack_id: str
+    severity: AdversarialFindingSeverity = AdversarialFindingSeverity.CRITICAL
+
+
+# A small default registry of widely-recognised cross-agent TTPs.
+DEFAULT_TTP_RULES: tuple[TTPRule, ...] = (
+    TTPRule(
+        rule_id="credential-shuck-and-pivot",
+        description=(
+            "Agent A retrieves a credential; agent B (within the same "
+            "window) uses the same credential against a separate "
+            "principal -- classic intra-fleet pivot."
+        ),
+        action_sequence=("credential:read", "credential:use"),
+        window_seconds=60.0,
+        mitre_attack_id="T1552",  # Unsecured Credentials
+    ),
+    TTPRule(
+        rule_id="staged-tool-handoff",
+        description=(
+            "Agent A stages a payload to shared storage; agent B "
+            "executes from that storage. Common evasion of per-agent "
+            "capability gates."
+        ),
+        action_sequence=("io:write_shared", "tool:execute_from_shared"),
+        window_seconds=120.0,
+        mitre_attack_id="T1105",  # Ingress Tool Transfer
+    ),
+)
+
+
+class CrossAgentCollusionDetector:
+    """TTP-rule engine on cross-agent action streams."""
+
+    detector_id: str = "cross-agent-collusion-v1"
+
+    def __init__(
+        self,
+        *,
+        rules: Sequence[TTPRule] = DEFAULT_TTP_RULES,
+    ) -> None:
+        if not rules:
+            raise ValueError("CrossAgentCollusionDetector requires at least one rule")
+        seen: set[str] = set()
+        for r in rules:
+            if r.rule_id in seen:
+                raise ValueError(f"duplicate rule_id: {r.rule_id!r}")
+            seen.add(r.rule_id)
+            if len(r.action_sequence) < 2:
+                raise ValueError(
+                    f"rule {r.rule_id!r}: action_sequence must have >= 2 actions"
+                )
+            if r.window_seconds <= 0:
+                raise ValueError(f"rule {r.rule_id!r}: window_seconds must be positive")
+        self._rules: tuple[TTPRule, ...] = tuple(rules)
+
+    def detect(
+        self,
+        *,
+        events: Sequence[AgentActionEvent],
+        delegations: Sequence[DelegationEdge] = (),
+    ) -> tuple[AdversarialFinding, ...]:
+        # Group events by action_name for fast lookup.
+        by_action: dict[str, list[AgentActionEvent]] = defaultdict(list)
+        for e in events:
+            by_action[e.action_name].append(e)
+
+        findings: list[AdversarialFinding] = []
+        for rule in self._rules:
+            findings.extend(self._match_rule(rule, by_action))
+        return tuple(findings)
+
+    def _match_rule(
+        self,
+        rule: TTPRule,
+        by_action: dict[str, list[AgentActionEvent]],
+    ) -> list[AdversarialFinding]:
+        """Find ordered matches for ``rule.action_sequence`` across agents.
+
+        For each anchor event matching the first action, look for a
+        subsequent event matching the second action by a DIFFERENT
+        agent within the time window; continue for the rest of the
+        sequence. Emits one finding per fully-matched sequence.
+        """
+        first_action = rule.action_sequence[0]
+        anchors = by_action.get(first_action, ())
+        out: list[AdversarialFinding] = []
+        window = timedelta(seconds=rule.window_seconds)
+        for anchor in anchors:
+            matched_events: list[AgentActionEvent] = [anchor]
+            used_agents: set[str] = {anchor.agent_id}
+            current_time = anchor.timestamp
+            ok = True
+            for next_action in rule.action_sequence[1:]:
+                # Find the earliest candidate after current_time, by a
+                # NEW agent, within the window from the anchor.
+                candidates = [
+                    e
+                    for e in by_action.get(next_action, ())
+                    if e.timestamp > current_time
+                    and e.agent_id not in used_agents
+                    and e.timestamp - anchor.timestamp <= window
+                ]
+                if not candidates:
+                    ok = False
+                    break
+                pick = min(candidates, key=lambda e: e.timestamp)
+                matched_events.append(pick)
+                used_agents.add(pick.agent_id)
+                current_time = pick.timestamp
+            if ok:
+                primary = matched_events[0].agent_id
+                others = tuple(sorted({e.agent_id for e in matched_events[1:]}))
+                out.append(
+                    AdversarialFinding(
+                        finding_id=str(uuid.uuid4()),
+                        pattern_name=rule.rule_id,
+                        detector_id=self.detector_id,
+                        severity=rule.severity,
+                        agent_id=primary,
+                        secondary_agent_ids=others,
+                        mitre_attack_id=rule.mitre_attack_id,
+                        rationale=rule.description,
+                        evidence={
+                            "rule_id": rule.rule_id,
+                            "matched_actions": [e.action_name for e in matched_events],
+                            "matched_agents": [e.agent_id for e in matched_events],
+                            "span_seconds": (
+                                matched_events[-1].timestamp
+                                - matched_events[0].timestamp
+                            ).total_seconds(),
+                        },
+                    )
+                )
+        return out

--- a/src/services/runtime_security/adversarial_detector/contracts.py
+++ b/src/services/runtime_security/adversarial_detector/contracts.py
@@ -1,0 +1,81 @@
+"""Data contracts for adversarial-agent detection (issue #211)."""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+class AdversarialFindingSeverity(enum.Enum):
+    """Severity bands aligned with the existing runtime_security.Severity."""
+
+    CRITICAL = "CRITICAL"
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+    LOW = "LOW"
+    INFO = "INFO"
+
+
+@dataclass(frozen=True)
+class AgentActionEvent:
+    """A single agent action observed in the runtime stream.
+
+    A small, focused slice of ``RuntimeEvent`` -- only the fields the
+    adversarial detectors actually use. Existing instrumentation
+    derives one of these per ``RuntimeEvent`` via a small adapter
+    layer (not shipped here; the adapter is a one-line projection
+    consumers wire up).
+    """
+
+    agent_id: str
+    action_name: str  # e.g. "bedrock:InvokeModel", "tool:fs.write"
+    timestamp: datetime
+    capability_tier: int = 0  # 0=basic, 1=elevated, 2=privileged, 3=admin
+    action_kind: str = "tool"  # "tool" | "delegation" | "credential" | "io"
+    mitre_attack_id: str = ""
+
+
+@dataclass(frozen=True)
+class DelegationEdge:
+    """A delegation observed between two agents.
+
+    Mirrors ADR-086 Phase 3's DelegationAssertion in shape; the
+    detector consumes only the structural fields it cares about so
+    it stays decoupled from the full assertion implementation.
+    """
+
+    from_agent_id: str
+    to_agent_id: str
+    timestamp: datetime
+    depth: int = 1  # ADR-086 depth-bound; > 3 is unusual
+
+
+@dataclass(frozen=True)
+class AdversarialFinding:
+    """One detection emitted by an adversarial detector."""
+
+    finding_id: str
+    pattern_name: str  # e.g. "slow-roll-capability-creep"
+    detector_id: str
+    severity: AdversarialFindingSeverity
+    agent_id: str  # primary agent the finding is about
+    secondary_agent_ids: tuple[str, ...] = ()  # for cross-agent patterns
+    mitre_attack_id: str = ""
+    rationale: str = ""
+    evidence: dict = field(default_factory=dict)
+    detected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_audit_dict(self) -> dict:
+        return {
+            "finding_id": self.finding_id,
+            "pattern_name": self.pattern_name,
+            "detector_id": self.detector_id,
+            "severity": self.severity.value,
+            "agent_id": self.agent_id,
+            "secondary_agent_ids": list(self.secondary_agent_ids),
+            "mitre_attack_id": self.mitre_attack_id,
+            "rationale": self.rationale,
+            "evidence": self.evidence,
+            "detected_at": self.detected_at.isoformat(),
+        }

--- a/src/services/runtime_security/adversarial_detector/delegation_shape.py
+++ b/src/services/runtime_security/adversarial_detector/delegation_shape.py
@@ -1,0 +1,158 @@
+"""Delegation-graph-shape anomaly detector (issue #211).
+
+Detects an agent whose outgoing delegation pattern is structurally
+unusual against a configured population baseline:
+
+  - **Star** -- one agent delegating to many distinct targets.
+  - **Deep chain** -- depth exceeds the ADR-086 depth-bound (default 3).
+  - **Rapid fan-out** -- many delegations in a short window.
+
+The detector takes a sequence of ``DelegationEdge`` records (already
+present per ADR-086 Phase 3) and runs three structural rules.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from datetime import timedelta
+from typing import Sequence
+
+from src.services.runtime_security.adversarial_detector.contracts import (
+    AdversarialFinding,
+    AdversarialFindingSeverity,
+    AgentActionEvent,
+    DelegationEdge,
+)
+
+
+class DelegationGraphShapeDetector:
+    """Flags agents with anomalous outbound delegation patterns."""
+
+    detector_id: str = "delegation-shape-v1"
+    pattern_name_star: str = "delegation-star-topology"
+    pattern_name_chain: str = "delegation-depth-exceeded"
+    pattern_name_fanout: str = "delegation-rapid-fanout"
+    mitre_attack_id: str = "T1098"  # Account Manipulation
+
+    def __init__(
+        self,
+        *,
+        star_target_threshold: int = 8,
+        depth_threshold: int = 3,
+        fanout_window_seconds: float = 60.0,
+        fanout_count_threshold: int = 6,
+    ) -> None:
+        if star_target_threshold < 2:
+            raise ValueError("star_target_threshold must be >= 2")
+        if depth_threshold < 1:
+            raise ValueError("depth_threshold must be >= 1")
+        if fanout_window_seconds <= 0:
+            raise ValueError("fanout_window_seconds must be positive")
+        if fanout_count_threshold < 2:
+            raise ValueError("fanout_count_threshold must be >= 2")
+        self._star_threshold = star_target_threshold
+        self._depth_threshold = depth_threshold
+        self._fanout_window = timedelta(seconds=fanout_window_seconds)
+        self._fanout_count = fanout_count_threshold
+
+    def detect(
+        self,
+        *,
+        events: Sequence[AgentActionEvent],
+        delegations: Sequence[DelegationEdge] = (),
+    ) -> tuple[AdversarialFinding, ...]:
+        if not delegations:
+            return ()
+
+        findings: list[AdversarialFinding] = []
+        out_edges: dict[str, list[DelegationEdge]] = defaultdict(list)
+        for edge in delegations:
+            out_edges[edge.from_agent_id].append(edge)
+
+        # Star detection.
+        for agent_id, edges in out_edges.items():
+            distinct_targets = {e.to_agent_id for e in edges}
+            if len(distinct_targets) >= self._star_threshold:
+                findings.append(
+                    AdversarialFinding(
+                        finding_id=str(uuid.uuid4()),
+                        pattern_name=self.pattern_name_star,
+                        detector_id=self.detector_id,
+                        severity=AdversarialFindingSeverity.HIGH,
+                        agent_id=agent_id,
+                        secondary_agent_ids=tuple(sorted(distinct_targets)),
+                        mitre_attack_id=self.mitre_attack_id,
+                        rationale=(
+                            f"Agent delegated to {len(distinct_targets)} "
+                            f"distinct targets (threshold "
+                            f"{self._star_threshold}). Star topology is "
+                            f"consistent with credential-spraying or "
+                            f"orchestration of a sub-fleet for collusion."
+                        ),
+                        evidence={
+                            "target_count": len(distinct_targets),
+                            "edge_count": len(edges),
+                        },
+                    )
+                )
+
+        # Depth-exceeded detection.
+        for edge in delegations:
+            if edge.depth > self._depth_threshold:
+                findings.append(
+                    AdversarialFinding(
+                        finding_id=str(uuid.uuid4()),
+                        pattern_name=self.pattern_name_chain,
+                        detector_id=self.detector_id,
+                        severity=AdversarialFindingSeverity.CRITICAL,
+                        agent_id=edge.from_agent_id,
+                        secondary_agent_ids=(edge.to_agent_id,),
+                        mitre_attack_id=self.mitre_attack_id,
+                        rationale=(
+                            f"Delegation depth {edge.depth} exceeds "
+                            f"ADR-086 depth-bound "
+                            f"({self._depth_threshold}). Deep chains evade "
+                            f"per-hop authorisation review."
+                        ),
+                        evidence={
+                            "depth": edge.depth,
+                            "threshold": self._depth_threshold,
+                            "to_agent": edge.to_agent_id,
+                        },
+                    )
+                )
+
+        # Rapid fan-out detection (per agent, sliding window).
+        for agent_id, edges in out_edges.items():
+            edges_sorted = sorted(edges, key=lambda e: e.timestamp)
+            for i, anchor in enumerate(edges_sorted):
+                window_end = anchor.timestamp + self._fanout_window
+                count = sum(1 for e in edges_sorted[i:] if e.timestamp <= window_end)
+                if count >= self._fanout_count:
+                    findings.append(
+                        AdversarialFinding(
+                            finding_id=str(uuid.uuid4()),
+                            pattern_name=self.pattern_name_fanout,
+                            detector_id=self.detector_id,
+                            severity=AdversarialFindingSeverity.HIGH,
+                            agent_id=agent_id,
+                            secondary_agent_ids=tuple(
+                                sorted(
+                                    {e.to_agent_id for e in edges_sorted[i : i + count]}
+                                )
+                            ),
+                            mitre_attack_id=self.mitre_attack_id,
+                            rationale=(
+                                f"{count} delegations within "
+                                f"{self._fanout_window.total_seconds():.0f}s "
+                                f"(threshold {self._fanout_count})."
+                            ),
+                            evidence={
+                                "count_in_window": count,
+                                "window_seconds": self._fanout_window.total_seconds(),
+                            },
+                        )
+                    )
+                    break  # one fanout finding per agent is enough
+        return tuple(findings)

--- a/src/services/runtime_security/adversarial_detector/dormancy_burst.py
+++ b/src/services/runtime_security/adversarial_detector/dormancy_burst.py
@@ -1,0 +1,127 @@
+"""Dormancy-then-burst detector (issue #211).
+
+Detects an agent that is idle for an extended period then issues a
+large coordinated action sequence within a small wall-clock window.
+
+Algorithm: compute inter-event time deltas for an agent. Take the
+z-score of the largest gap relative to the population of gaps. If
+the largest gap is multiple standard deviations above the mean
+AND it is followed by a burst (>= ``burst_count`` events within
+``burst_window_seconds``), fire a HIGH finding.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from collections import defaultdict
+from typing import Sequence
+
+from src.services.runtime_security.adversarial_detector.contracts import (
+    AdversarialFinding,
+    AdversarialFindingSeverity,
+    AgentActionEvent,
+    DelegationEdge,
+)
+
+
+class DormancyThenBurstDetector:
+    """Flags long idle period followed by a coordinated burst.
+
+    The detector is intentionally insensitive to short bursts that
+    happen during normal use -- it only fires when the gap before
+    the burst is statistically anomalous AND the burst is dense.
+    """
+
+    detector_id: str = "dormancy-burst-v1"
+    pattern_name: str = "dormancy-then-burst"
+    mitre_attack_id: str = "T1029"  # Scheduled Transfer (closest match)
+
+    def __init__(
+        self,
+        *,
+        gap_z_threshold: float = 3.0,
+        burst_count: int = 8,
+        burst_window_seconds: float = 60.0,
+        min_events_per_agent: int = 10,
+    ) -> None:
+        if gap_z_threshold <= 0:
+            raise ValueError("gap_z_threshold must be positive")
+        if burst_count < 2:
+            raise ValueError("burst_count must be >= 2")
+        if burst_window_seconds <= 0:
+            raise ValueError("burst_window_seconds must be positive")
+        self._z_threshold = gap_z_threshold
+        self._burst_count = burst_count
+        self._burst_window = burst_window_seconds
+        self._min_events = min_events_per_agent
+
+    def detect(
+        self,
+        *,
+        events: Sequence[AgentActionEvent],
+        delegations: Sequence[DelegationEdge] = (),
+    ) -> tuple[AdversarialFinding, ...]:
+        by_agent: dict[str, list[AgentActionEvent]] = defaultdict(list)
+        for e in events:
+            by_agent[e.agent_id].append(e)
+
+        findings: list[AdversarialFinding] = []
+        for agent_id, agent_events in by_agent.items():
+            if len(agent_events) < self._min_events:
+                continue
+            agent_events.sort(key=lambda e: e.timestamp)
+            gaps_seconds: list[float] = []
+            for i in range(1, len(agent_events)):
+                delta = (
+                    agent_events[i].timestamp - agent_events[i - 1].timestamp
+                ).total_seconds()
+                gaps_seconds.append(delta)
+            if not gaps_seconds:
+                continue
+            mean = sum(gaps_seconds) / len(gaps_seconds)
+            variance = sum((g - mean) ** 2 for g in gaps_seconds) / len(gaps_seconds)
+            stdev = math.sqrt(variance) if variance > 0 else 0.0
+            if stdev == 0:
+                continue
+            # Find the largest gap and its z-score.
+            max_gap_idx = max(range(len(gaps_seconds)), key=lambda i: gaps_seconds[i])
+            max_gap = gaps_seconds[max_gap_idx]
+            z = (max_gap - mean) / stdev
+            if z < self._z_threshold:
+                continue
+            # Check whether the events AFTER the gap form a burst.
+            post_gap_events = agent_events[max_gap_idx + 1 :]
+            if len(post_gap_events) < self._burst_count:
+                continue
+            window_end = post_gap_events[0].timestamp.timestamp() + self._burst_window
+            burst_in_window = sum(
+                1 for e in post_gap_events if e.timestamp.timestamp() <= window_end
+            )
+            if burst_in_window < self._burst_count:
+                continue
+
+            findings.append(
+                AdversarialFinding(
+                    finding_id=str(uuid.uuid4()),
+                    pattern_name=self.pattern_name,
+                    detector_id=self.detector_id,
+                    severity=AdversarialFindingSeverity.HIGH,
+                    agent_id=agent_id,
+                    mitre_attack_id=self.mitre_attack_id,
+                    rationale=(
+                        f"Idle gap of {max_gap:.0f}s (z={z:.2f}) followed by "
+                        f"a burst of {burst_in_window} events within "
+                        f"{self._burst_window:.0f}s. Pattern is consistent "
+                        f"with a sleeper-then-active adversarial schedule."
+                    ),
+                    evidence={
+                        "max_gap_seconds": max_gap,
+                        "gap_z_score": z,
+                        "burst_event_count": burst_in_window,
+                        "burst_window_seconds": self._burst_window,
+                        "agent_event_count": len(agent_events),
+                    },
+                )
+            )
+        return tuple(findings)

--- a/src/services/runtime_security/adversarial_detector/port.py
+++ b/src/services/runtime_security/adversarial_detector/port.py
@@ -1,0 +1,64 @@
+"""Port + dispatcher for adversarial detection (issue #211)."""
+
+from __future__ import annotations
+
+from typing import Iterable, Protocol, Sequence
+
+from src.services.runtime_security.adversarial_detector.contracts import (
+    AdversarialFinding,
+    AgentActionEvent,
+    DelegationEdge,
+)
+
+
+class AdversarialDetectorPort(Protocol):
+    """A single adversarial-pattern detector.
+
+    Implementations must be **deterministic** and **side-effect-free**
+    given a fixed event stream (so a re-run produces the same
+    findings). Each detector focuses on ONE named pattern.
+    """
+
+    detector_id: str
+
+    def detect(
+        self,
+        *,
+        events: Sequence[AgentActionEvent],
+        delegations: Sequence[DelegationEdge] = (),
+    ) -> tuple[AdversarialFinding, ...]:
+        """Return zero or more findings for the given event stream."""
+
+
+class AdversarialDetectorDispatcher:
+    """Runs a set of detectors and aggregates their findings.
+
+    Deliberately synchronous + serial -- the detectors are cheap and
+    serial execution keeps the audit trail deterministic. Tests pass
+    a single detector; production wires the full set.
+    """
+
+    def __init__(self, detectors: Iterable[AdversarialDetectorPort]) -> None:
+        self._detectors: tuple[AdversarialDetectorPort, ...] = tuple(detectors)
+        seen: set[str] = set()
+        for d in self._detectors:
+            if d.detector_id in seen:
+                raise ValueError(
+                    f"Duplicate detector_id in dispatcher: {d.detector_id!r}"
+                )
+            seen.add(d.detector_id)
+
+    @property
+    def detector_ids(self) -> tuple[str, ...]:
+        return tuple(d.detector_id for d in self._detectors)
+
+    def detect(
+        self,
+        *,
+        events: Sequence[AgentActionEvent],
+        delegations: Sequence[DelegationEdge] = (),
+    ) -> tuple[AdversarialFinding, ...]:
+        aggregated: list[AdversarialFinding] = []
+        for detector in self._detectors:
+            aggregated.extend(detector.detect(events=events, delegations=delegations))
+        return tuple(aggregated)

--- a/src/services/runtime_security/adversarial_detector/slow_roll.py
+++ b/src/services/runtime_security/adversarial_detector/slow_roll.py
@@ -1,0 +1,155 @@
+"""Slow-roll capability-creep detector (issue #211).
+
+Detects an agent that requests progressively *more* privileged tools
+over a long window, even when each request individually looks normal.
+
+Algorithm: bucket the agent's events into a configurable number of
+equal-sized time buckets, compute the mean capability tier per
+bucket, and check whether the sequence is monotonically (or near-
+monotonically) increasing. The strength of the upward trend is
+measured by Spearman-style rank correlation between bucket index
+and bucket-mean capability tier; a coefficient above the threshold
+fires a HIGH finding.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from typing import Sequence
+
+from src.services.runtime_security.adversarial_detector.contracts import (
+    AdversarialFinding,
+    AdversarialFindingSeverity,
+    AgentActionEvent,
+    DelegationEdge,
+)
+
+
+def _spearman_rank_correlation(values: Sequence[float]) -> float:
+    """Spearman rank correlation between the natural index 0..n-1 and ``values``.
+
+    Returns a float in [-1.0, 1.0]. Implemented from scratch to avoid
+    pulling scipy into a runtime security path.
+    """
+    n = len(values)
+    if n < 2:
+        return 0.0
+    # Compute ranks (1-indexed) with ties resolved by averaging.
+    enumerated = sorted(enumerate(values), key=lambda p: p[1])
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and enumerated[j + 1][1] == enumerated[i][1]:
+            j += 1
+        # Average rank for ties.
+        avg_rank = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1):
+            ranks[enumerated[k][0]] = avg_rank
+        i = j + 1
+    # Index ranks are 1..n exactly.
+    index_ranks = [float(k + 1) for k in range(n)]
+    mean_idx = (n + 1) / 2.0
+    mean_val = sum(ranks) / n
+    num = sum((index_ranks[k] - mean_idx) * (ranks[k] - mean_val) for k in range(n))
+    den_idx = sum((r - mean_idx) ** 2 for r in index_ranks)
+    den_val = sum((r - mean_val) ** 2 for r in ranks)
+    if den_idx == 0 or den_val == 0:
+        return 0.0
+    return num / ((den_idx * den_val) ** 0.5)
+
+
+class SlowRollCapabilityCreepDetector:
+    """Flags agents whose capability-tier usage trends upward.
+
+    Defaults assume a 4-tier capability scale (basic=0, elevated=1,
+    privileged=2, admin=3). The detector buckets events into 5
+    equal-sized time slices and fires a HIGH finding when the
+    Spearman correlation between bucket index and bucket-mean tier
+    exceeds ``trend_threshold`` (default 0.85).
+    """
+
+    detector_id: str = "slow-roll-capability-creep-v1"
+    pattern_name: str = "slow-roll-capability-creep"
+    mitre_attack_id: str = "T1548"  # Abuse Elevation Control Mechanism
+
+    def __init__(
+        self,
+        *,
+        bucket_count: int = 5,
+        trend_threshold: float = 0.85,
+        min_events_per_agent: int = 10,
+    ) -> None:
+        if bucket_count < 2:
+            raise ValueError("bucket_count must be >= 2")
+        if not 0.0 < trend_threshold <= 1.0:
+            raise ValueError("trend_threshold must be in (0, 1]")
+        self._bucket_count = bucket_count
+        self._trend_threshold = trend_threshold
+        self._min_events = min_events_per_agent
+
+    def detect(
+        self,
+        *,
+        events: Sequence[AgentActionEvent],
+        delegations: Sequence[DelegationEdge] = (),
+    ) -> tuple[AdversarialFinding, ...]:
+        # Group events by agent.
+        by_agent: dict[str, list[AgentActionEvent]] = defaultdict(list)
+        for e in events:
+            by_agent[e.agent_id].append(e)
+
+        findings: list[AdversarialFinding] = []
+        for agent_id, agent_events in by_agent.items():
+            if len(agent_events) < self._min_events:
+                continue
+            agent_events.sort(key=lambda e: e.timestamp)
+            # Equal-count buckets (more stable than equal-time when
+            # events arrive in bursts).
+            bucket_size = max(1, len(agent_events) // self._bucket_count)
+            bucket_means: list[float] = []
+            for b in range(self._bucket_count):
+                lo = b * bucket_size
+                hi = (
+                    lo + bucket_size
+                    if b < self._bucket_count - 1
+                    else len(agent_events)
+                )
+                bucket = agent_events[lo:hi]
+                if not bucket:
+                    continue
+                bucket_means.append(
+                    sum(e.capability_tier for e in bucket) / len(bucket)
+                )
+            if len(bucket_means) < 2:
+                continue
+            correlation = _spearman_rank_correlation(bucket_means)
+            if correlation < self._trend_threshold:
+                continue
+            findings.append(
+                AdversarialFinding(
+                    finding_id=str(uuid.uuid4()),
+                    pattern_name=self.pattern_name,
+                    detector_id=self.detector_id,
+                    severity=AdversarialFindingSeverity.HIGH,
+                    agent_id=agent_id,
+                    mitre_attack_id=self.mitre_attack_id,
+                    rationale=(
+                        f"Capability-tier mean across {len(bucket_means)} "
+                        f"buckets shows monotone upward trend "
+                        f"(Spearman={correlation:.3f}, "
+                        f"threshold={self._trend_threshold:.2f}). "
+                        f"Bucket means: "
+                        f"{[round(m, 2) for m in bucket_means]}."
+                    ),
+                    evidence={
+                        "bucket_count": len(bucket_means),
+                        "bucket_means": bucket_means,
+                        "spearman_correlation": correlation,
+                        "threshold": self._trend_threshold,
+                        "agent_event_count": len(agent_events),
+                    },
+                )
+            )
+        return tuple(findings)

--- a/tests/services/runtime_security/adversarial_detector/test_adversarial_detector.py
+++ b/tests/services/runtime_security/adversarial_detector/test_adversarial_detector.py
@@ -1,0 +1,289 @@
+"""Tests for the adversarial-agent detector layer (issue #211)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.services.runtime_security.adversarial_detector import (
+    AdversarialDetectorDispatcher,
+    AdversarialFindingSeverity,
+    AgentActionEvent,
+    CrossAgentCollusionDetector,
+    DelegationEdge,
+    DelegationGraphShapeDetector,
+    DormancyThenBurstDetector,
+    SlowRollCapabilityCreepDetector,
+    TTPRule,
+)
+
+_NOW = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _ev(
+    agent: str,
+    name: str,
+    tier: int,
+    seconds_offset: float,
+    kind: str = "tool",
+) -> AgentActionEvent:
+    return AgentActionEvent(
+        agent_id=agent,
+        action_name=name,
+        timestamp=_NOW + timedelta(seconds=seconds_offset),
+        capability_tier=tier,
+        action_kind=kind,
+    )
+
+
+# =============================================================================
+# Slow-roll capability creep
+# =============================================================================
+
+
+class TestSlowRollCapabilityCreep:
+    def test_steady_low_tier_produces_no_finding(self):
+        det = SlowRollCapabilityCreepDetector()
+        events = [_ev("a1", "tool:read", 0, i) for i in range(20)]
+        findings = det.detect(events=events)
+        assert findings == ()
+
+    def test_clear_upward_trend_fires(self):
+        det = SlowRollCapabilityCreepDetector()
+        # Bucket means progress 0, 1, 2, 3, 3 -> clearly monotone.
+        events: list[AgentActionEvent] = []
+        for i, tier in enumerate([0] * 5 + [1] * 5 + [2] * 5 + [3] * 5):
+            events.append(_ev("creeper", "tool:x", tier, i))
+        findings = det.detect(events=events)
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding.agent_id == "creeper"
+        assert finding.pattern_name == "slow-roll-capability-creep"
+        assert finding.mitre_attack_id == "T1548"
+        assert finding.severity == AdversarialFindingSeverity.HIGH
+        assert finding.evidence["spearman_correlation"] >= 0.85
+
+    def test_insufficient_events_does_not_fire(self):
+        det = SlowRollCapabilityCreepDetector(min_events_per_agent=10)
+        events = [_ev("short", "tool:x", i, i) for i in range(5)]
+        assert det.detect(events=events) == ()
+
+    def test_normal_agent_with_high_constant_tier_does_not_fire(self):
+        # An admin-tier agent that consistently uses admin tools should
+        # NOT fire -- that's their baseline, not creep.
+        det = SlowRollCapabilityCreepDetector()
+        events = [_ev("admin", "tool:x", 3, i) for i in range(20)]
+        assert det.detect(events=events) == ()
+
+
+# =============================================================================
+# Dormancy then burst
+# =============================================================================
+
+
+class TestDormancyThenBurst:
+    def test_steady_cadence_produces_no_finding(self):
+        det = DormancyThenBurstDetector()
+        # 30 events at 10s spacing.
+        events = [_ev("steady", "tool:x", 0, i * 10) for i in range(30)]
+        assert det.detect(events=events) == ()
+
+    def test_long_dormancy_then_burst_fires(self):
+        det = DormancyThenBurstDetector(
+            gap_z_threshold=2.0, burst_count=8, burst_window_seconds=60.0
+        )
+        # 10 events tightly spaced...
+        events = [_ev("sleeper", "tool:x", 0, i * 5) for i in range(10)]
+        # ...then a long idle gap...
+        events.append(_ev("sleeper", "tool:x", 0, 50_000))
+        # ...then a burst of 9 events within 30s.
+        events.extend(_ev("sleeper", "tool:x", 0, 50_000 + i * 3) for i in range(1, 9))
+        findings = det.detect(events=events)
+        assert len(findings) == 1
+        assert findings[0].pattern_name == "dormancy-then-burst"
+        assert findings[0].mitre_attack_id == "T1029"
+        assert findings[0].evidence["max_gap_seconds"] > 1000
+
+    def test_low_z_score_does_not_fire(self):
+        det = DormancyThenBurstDetector(gap_z_threshold=5.0)
+        events = [_ev("not-sus", "tool:x", 0, i * 10) for i in range(20)]
+        events.append(_ev("not-sus", "tool:x", 0, 220))  # slight gap
+        events.extend(_ev("not-sus", "tool:x", 0, 220 + i) for i in range(1, 12))
+        assert det.detect(events=events) == ()
+
+
+# =============================================================================
+# Delegation graph shape
+# =============================================================================
+
+
+def _del(from_a: str, to_a: str, seconds: float, depth: int = 1) -> DelegationEdge:
+    return DelegationEdge(
+        from_agent_id=from_a,
+        to_agent_id=to_a,
+        timestamp=_NOW + timedelta(seconds=seconds),
+        depth=depth,
+    )
+
+
+class TestDelegationGraphShape:
+    def test_no_delegations_no_finding(self):
+        det = DelegationGraphShapeDetector()
+        assert det.detect(events=()) == ()
+
+    def test_star_topology_fires(self):
+        det = DelegationGraphShapeDetector(star_target_threshold=5)
+        delegations = [_del("hub", f"spoke-{i}", i * 60) for i in range(7)]
+        findings = det.detect(events=(), delegations=delegations)
+        names = [f.pattern_name for f in findings]
+        assert "delegation-star-topology" in names
+        star = next(f for f in findings if f.pattern_name == "delegation-star-topology")
+        assert star.agent_id == "hub"
+        assert len(star.secondary_agent_ids) == 7
+
+    def test_depth_exceeded_fires(self):
+        det = DelegationGraphShapeDetector(depth_threshold=3)
+        delegations = [_del("a", "b", 0, depth=5)]
+        findings = det.detect(events=(), delegations=delegations)
+        assert any(
+            f.pattern_name == "delegation-depth-exceeded"
+            and f.severity == AdversarialFindingSeverity.CRITICAL
+            for f in findings
+        )
+
+    def test_rapid_fanout_fires(self):
+        det = DelegationGraphShapeDetector(
+            star_target_threshold=20,  # disable star
+            fanout_window_seconds=30.0,
+            fanout_count_threshold=5,
+        )
+        delegations = [_del("fan", f"target-{i}", i * 4) for i in range(8)]  # 8 in 28s
+        findings = det.detect(events=(), delegations=delegations)
+        assert any(f.pattern_name == "delegation-rapid-fanout" for f in findings)
+
+    def test_normal_one_off_delegation_no_finding(self):
+        det = DelegationGraphShapeDetector()
+        assert det.detect(events=(), delegations=[_del("a", "b", 0)]) == ()
+
+
+# =============================================================================
+# Cross-agent collusion
+# =============================================================================
+
+
+class TestCrossAgentCollusion:
+    def test_default_rules_fire_on_credential_shuck(self):
+        det = CrossAgentCollusionDetector()
+        events = (
+            _ev("alice", "credential:read", 0, 0, kind="credential"),
+            _ev("bob", "credential:use", 0, 10, kind="credential"),
+        )
+        findings = det.detect(events=events)
+        assert len(findings) == 1
+        assert findings[0].pattern_name == "credential-shuck-and-pivot"
+        assert findings[0].agent_id == "alice"
+        assert "bob" in findings[0].secondary_agent_ids
+        assert findings[0].mitre_attack_id == "T1552"
+
+    def test_default_rules_fire_on_staged_handoff(self):
+        det = CrossAgentCollusionDetector()
+        events = (
+            _ev("uploader", "io:write_shared", 0, 0, kind="io"),
+            _ev("executor", "tool:execute_from_shared", 0, 30),
+        )
+        findings = det.detect(events=events)
+        assert len(findings) == 1
+        assert findings[0].pattern_name == "staged-tool-handoff"
+
+    def test_same_agent_does_not_match_collusion(self):
+        det = CrossAgentCollusionDetector()
+        events = (
+            _ev("loner", "credential:read", 0, 0, kind="credential"),
+            _ev("loner", "credential:use", 0, 10, kind="credential"),
+        )
+        # Same agent both steps -> not collusion.
+        assert det.detect(events=events) == ()
+
+    def test_outside_window_does_not_match(self):
+        det = CrossAgentCollusionDetector()
+        events = (
+            _ev("alice", "credential:read", 0, 0, kind="credential"),
+            _ev("bob", "credential:use", 0, 3600, kind="credential"),
+        )
+        # Default window is 60s; 1h gap should not match.
+        assert det.detect(events=events) == ()
+
+    def test_custom_rule(self):
+        custom = TTPRule(
+            rule_id="custom",
+            description="custom",
+            action_sequence=("step1", "step2", "step3"),
+            window_seconds=300.0,
+            mitre_attack_id="T9999",
+        )
+        det = CrossAgentCollusionDetector(rules=(custom,))
+        events = (
+            _ev("a1", "step1", 0, 0),
+            _ev("a2", "step2", 0, 10),
+            _ev("a3", "step3", 0, 20),
+        )
+        findings = det.detect(events=events)
+        assert len(findings) == 1
+        assert findings[0].pattern_name == "custom"
+        assert findings[0].mitre_attack_id == "T9999"
+
+    def test_invalid_rule_rejected(self):
+        with pytest.raises(ValueError):
+            CrossAgentCollusionDetector(rules=())
+        bad_seq = TTPRule(
+            rule_id="x",
+            description="x",
+            action_sequence=("only-one",),
+            window_seconds=60,
+            mitre_attack_id="T0",
+        )
+        with pytest.raises(ValueError):
+            CrossAgentCollusionDetector(rules=(bad_seq,))
+
+
+# =============================================================================
+# Dispatcher
+# =============================================================================
+
+
+class TestDispatcher:
+    def test_dispatcher_aggregates(self):
+        events = [_ev("creeper", "tool:x", i // 5, i) for i in range(20)]
+        delegations = [_del("hub", f"spoke-{i}", i * 60) for i in range(10)]
+        dispatcher = AdversarialDetectorDispatcher(
+            [
+                SlowRollCapabilityCreepDetector(),
+                DelegationGraphShapeDetector(star_target_threshold=5),
+            ]
+        )
+        findings = dispatcher.detect(events=events, delegations=delegations)
+        names = {f.pattern_name for f in findings}
+        # Both detectors contributed at least one finding.
+        assert "slow-roll-capability-creep" in names
+        assert "delegation-star-topology" in names
+
+    def test_duplicate_detector_id_rejected(self):
+        with pytest.raises(ValueError):
+            AdversarialDetectorDispatcher(
+                [
+                    SlowRollCapabilityCreepDetector(),
+                    SlowRollCapabilityCreepDetector(),
+                ]
+            )
+
+    def test_finding_audit_dict_shape(self):
+        det = SlowRollCapabilityCreepDetector()
+        events = [_ev("creep", "tool:x", i // 5, i) for i in range(20)]
+        findings = det.detect(events=events)
+        assert findings, "expected at least one finding"
+        audit = findings[0].to_audit_dict()
+        assert audit["pattern_name"] == "slow-roll-capability-creep"
+        assert audit["mitre_attack_id"] == "T1548"
+        assert "evidence" in audit
+        assert "detected_at" in audit


### PR DESCRIPTION
## Summary

Closes #211. ADR-083's behavioural baseline catches agents whose behaviour *changes* after compromise; it does not catch agents *designed from the start* to look normal -- the baseline learns the adversarial behaviour as their baseline. This PR ships a signature-based detection layer that runs alongside the baseline engine and fires on four named adversarial patterns.

## Detectors

| Pattern | MITRE | Algorithm |
|---|---|---|
| Slow-roll capability creep | T1548 | Spearman rank correlation over capability-tier buckets; fires above threshold |
| Dormancy-then-burst | T1029 | z-score on inter-event gaps + burst density check within a configurable window |
| Delegation-graph shape | T1098 | Three structural rules: star topology, depth-bound exceeded, rapid fan-out |
| Cross-agent collusion | T1552 / T1105 (defaults) | TTPRule engine matching ordered action sequences across distinct agents within a window |

Detectors implement the same narrow \`AdversarialDetectorPort\` Protocol; \`AdversarialDetectorDispatcher\` aggregates them serially for deterministic audit. Findings emit \`AdversarialFinding\` records with MITRE ATT&CK IDs that the existing runtime_security event router consumes.

## Honest scope

- **Rule-based, not ML.** This layer is the documented narrow rule engine. ML-based behavioural classification is out of scope (separate effort).
- **Layer, not replacement.** Does not replace ADR-083's drift detection -- complements it.
- **Default TTP registry is small** (two rules). Operators wire their own \`TTPRule\` entries to cover org-specific adversarial patterns.
- **No real telemetry adapter shipped here.** The detectors consume \`AgentActionEvent\` and \`DelegationEdge\` DTOs. A one-line projection from the existing \`RuntimeEvent\` and ADR-086 Phase 3 \`DelegationAssertion\` records is the production wiring; not shipped here so the detector layer can be unit-tested in isolation.

## Test plan

- [x] 21 new tests in \`tests/services/runtime_security/adversarial_detector/test_adversarial_detector.py\` covering: each detector's positive + negative paths (steady cadence does NOT fire, clear pattern DOES fire), dispatcher aggregation, duplicate-id rejection, audit-dict shape, invalid-rule rejection.
- [x] Lint clean (black, flake8, isort, bandit).

## Related

- ADR-083 (Runtime Agent Security) -- parent; this layer complements its baseline engine
- ADR-086 Phase 3 (Agentic Identity Lifecycle) -- delegation graph data source
- Issues #209, #210, #212 -- sibling AI-vuln gap closures (one PR each)