### PR TITLE
feat(model-assurance): #212 -- consensus re-validation on Bedrock model bumps

### DIFF
--- a/src/services/model_assurance/model_upgrade_watcher/__init__.py
+++ b/src/services/model_assurance/model_upgrade_watcher/__init__.py
@@ -1,0 +1,44 @@
+"""Model-upgrade consensus re-validation watcher (issue #212).
+
+When the configured Bedrock model version bumps for any Aura tier,
+the statistical convergence properties of ADR-085's N-of-M consensus
+may shift. This module detects bumps, gates DAL A/B auto-promotion
+behind an SSM-backed feature flag, triggers the Frozen Reference
+Oracle (ADR-088) to re-run its reference cases against the new model,
+and either clears the flag (re-run pass) or opens a HITL incident
+(re-run fail).
+"""
+
+from src.services.model_assurance.model_upgrade_watcher.contracts import (
+    BedrockModelVersion,
+    ModelUpgradeEvent,
+    RevalidationOutcome,
+    RevalidationStatus,
+)
+from src.services.model_assurance.model_upgrade_watcher.coordinator import (
+    RevalidationCoordinator,
+)
+from src.services.model_assurance.model_upgrade_watcher.ports import (
+    BedrockModelRegistryPort,
+    HitlIncidentPort,
+    MetricEmitterPort,
+    OracleRerunPort,
+    RevalidationFlagPort,
+)
+from src.services.model_assurance.model_upgrade_watcher.watcher import (
+    ModelVersionWatcher,
+)
+
+__all__ = [
+    "BedrockModelRegistryPort",
+    "BedrockModelVersion",
+    "HitlIncidentPort",
+    "MetricEmitterPort",
+    "ModelUpgradeEvent",
+    "ModelVersionWatcher",
+    "OracleRerunPort",
+    "RevalidationCoordinator",
+    "RevalidationFlagPort",
+    "RevalidationOutcome",
+    "RevalidationStatus",
+]

--- a/src/services/model_assurance/model_upgrade_watcher/contracts.py
+++ b/src/services/model_assurance/model_upgrade_watcher/contracts.py
@@ -1,0 +1,88 @@
+"""Data contracts for the model-upgrade watcher (issue #212)."""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass(frozen=True)
+class BedrockModelVersion:
+    """Versioned identifier for one tier's Bedrock model.
+
+    ``tier`` is the Aura capability tier (STANDARD / ADVANCED).
+    ``model_id`` is the Bedrock model id (e.g.
+    'anthropic.claude-sonnet-4-7-20260120'). ``version`` is the
+    version string AWS exposes alongside the id; the watcher
+    treats a change in either as a bump.
+    """
+
+    tier: str
+    model_id: str
+    version: str = ""
+
+    @property
+    def identity(self) -> str:
+        """Combined identity used for change detection."""
+        return f"{self.model_id}@{self.version}" if self.version else self.model_id
+
+
+class RevalidationStatus(enum.Enum):
+    """Lifecycle status of a single re-validation pass."""
+
+    NOT_STARTED = "not_started"
+    IN_PROGRESS = "in_progress"
+    PASSED = "passed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class ModelUpgradeEvent:
+    """One detected bump (or absence of one) per watcher tick."""
+
+    detected_at: datetime
+    tier: str
+    previous: BedrockModelVersion
+    current: BedrockModelVersion
+
+    @property
+    def is_bump(self) -> bool:
+        return self.previous.identity != self.current.identity
+
+
+@dataclass(frozen=True)
+class RevalidationOutcome:
+    """Result of running the Frozen Reference Oracle against the new model."""
+
+    status: RevalidationStatus
+    tier: str
+    model_identity: str
+    cases_total: int = 0
+    cases_passed: int = 0
+    rationale: str = ""
+    incident_ticket_id: str = ""
+    flag_cleared: bool = False
+    flag_set: bool = False
+    metric_emitted: bool = False
+    completed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def passed(self) -> bool:
+        return self.status == RevalidationStatus.PASSED
+
+    def to_audit_dict(self) -> dict:
+        return {
+            "status": self.status.value,
+            "tier": self.tier,
+            "model_identity": self.model_identity,
+            "cases_total": self.cases_total,
+            "cases_passed": self.cases_passed,
+            "rationale": self.rationale,
+            "incident_ticket_id": self.incident_ticket_id,
+            "flag_cleared": self.flag_cleared,
+            "flag_set": self.flag_set,
+            "metric_emitted": self.metric_emitted,
+            "completed_at": self.completed_at.isoformat(),
+        }

--- a/src/services/model_assurance/model_upgrade_watcher/coordinator.py
+++ b/src/services/model_assurance/model_upgrade_watcher/coordinator.py
@@ -1,0 +1,195 @@
+"""Re-validation coordinator (issue #212).
+
+Glue that orchestrates the watcher + flag + Frozen Reference Oracle
++ HITL gateway + CloudWatch metric. The composition root for the
+issue #212 work.
+
+Lifecycle per bump:
+
+  1. Set the SSM-backed feature flag for the tier (blocks DAL A/B
+     auto-promotion immediately).
+  2. Trigger the Frozen Reference Oracle to re-run its reference
+     cases against the new model.
+  3. If pass-rate >= ``pass_rate_threshold``: clear the flag.
+     If not: open a HITL incident. Either way: emit a CloudWatch
+     metric data point.
+
+The coordinator is intentionally synchronous; production wraps it
+in a Lambda invocation and the EventBridge schedule drives the
+cadence. A single Lambda invocation processes whatever bumps the
+watcher detected on this tick (usually zero, occasionally one).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+from src.services.model_assurance.model_upgrade_watcher.contracts import (
+    ModelUpgradeEvent,
+    RevalidationOutcome,
+    RevalidationStatus,
+)
+from src.services.model_assurance.model_upgrade_watcher.ports import (
+    HitlIncidentPort,
+    MetricEmitterPort,
+    OracleRerunPort,
+    RevalidationFlagPort,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RevalidationCoordinator:
+    """Drive the bump -> re-validate -> clear/escalate lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        flag: RevalidationFlagPort,
+        oracle: OracleRerunPort,
+        incident: HitlIncidentPort,
+        metric: MetricEmitterPort,
+        pass_rate_threshold: float = 0.95,
+    ) -> None:
+        if not 0.0 < pass_rate_threshold <= 1.0:
+            raise ValueError("pass_rate_threshold must be in (0, 1]")
+        self._flag = flag
+        self._oracle = oracle
+        self._incident = incident
+        self._metric = metric
+        self._threshold = pass_rate_threshold
+
+    def process(
+        self,
+        events: Sequence[ModelUpgradeEvent],
+    ) -> tuple[RevalidationOutcome, ...]:
+        """Process events from one watcher tick; return per-event outcomes."""
+        outcomes: list[RevalidationOutcome] = []
+        for event in events:
+            if not event.is_bump:
+                outcomes.append(
+                    RevalidationOutcome(
+                        status=RevalidationStatus.SKIPPED,
+                        tier=event.tier,
+                        model_identity=event.current.identity,
+                        rationale="no model version change detected",
+                    )
+                )
+                continue
+            outcomes.append(self._handle_bump(event))
+        return tuple(outcomes)
+
+    def _handle_bump(self, event: ModelUpgradeEvent) -> RevalidationOutcome:
+        tier = event.tier
+        new_identity = event.current.identity
+        reason = (
+            f"Bedrock model bumped for tier {tier!r}: "
+            f"{event.previous.identity!r} -> {new_identity!r}. "
+            f"DAL A/B auto-promotion is blocked pending re-validation."
+        )
+        logger.warning(reason)
+        self._flag.set(tier=tier, reason=reason)
+        flag_set = True
+
+        try:
+            passed, total = self._oracle.rerun_reference_cases(
+                tier=tier, model_identity=new_identity
+            )
+        except Exception as exc:  # pragma: no cover -- oracle is best-effort
+            logger.exception(
+                "Oracle rerun raised; treating as FAILED for tier %s", tier
+            )
+            ticket = self._incident.open_incident(
+                tier=tier,
+                model_identity=new_identity,
+                cases_passed=0,
+                cases_total=0,
+                rationale=f"Oracle rerun raised: {exc}",
+            )
+            self._metric.emit(
+                tier=tier,
+                model_identity=new_identity,
+                status=RevalidationStatus.FAILED.value,
+                cases_passed=0,
+                cases_total=0,
+            )
+            return RevalidationOutcome(
+                status=RevalidationStatus.FAILED,
+                tier=tier,
+                model_identity=new_identity,
+                cases_total=0,
+                cases_passed=0,
+                rationale=f"oracle raised: {exc}",
+                incident_ticket_id=ticket,
+                flag_set=flag_set,
+                metric_emitted=True,
+            )
+
+        pass_rate = (passed / total) if total > 0 else 0.0
+        if pass_rate >= self._threshold:
+            self._flag.clear(tier=tier)
+            self._metric.emit(
+                tier=tier,
+                model_identity=new_identity,
+                status=RevalidationStatus.PASSED.value,
+                cases_passed=passed,
+                cases_total=total,
+            )
+            logger.info(
+                "Re-validation PASSED for tier %s: %d/%d cases (threshold %.2f)",
+                tier,
+                passed,
+                total,
+                self._threshold,
+            )
+            return RevalidationOutcome(
+                status=RevalidationStatus.PASSED,
+                tier=tier,
+                model_identity=new_identity,
+                cases_total=total,
+                cases_passed=passed,
+                rationale=(
+                    f"pass_rate={pass_rate:.3f} >= threshold={self._threshold:.2f}"
+                ),
+                flag_set=flag_set,
+                flag_cleared=True,
+                metric_emitted=True,
+            )
+
+        # Below threshold: keep the flag set, open a HITL incident.
+        ticket = self._incident.open_incident(
+            tier=tier,
+            model_identity=new_identity,
+            cases_passed=passed,
+            cases_total=total,
+            rationale=(
+                f"pass_rate={pass_rate:.3f} below threshold={self._threshold:.2f}"
+            ),
+        )
+        self._metric.emit(
+            tier=tier,
+            model_identity=new_identity,
+            status=RevalidationStatus.FAILED.value,
+            cases_passed=passed,
+            cases_total=total,
+        )
+        logger.warning(
+            "Re-validation FAILED for tier %s: %d/%d cases below threshold; "
+            "incident=%s",
+            tier,
+            passed,
+            total,
+            ticket,
+        )
+        return RevalidationOutcome(
+            status=RevalidationStatus.FAILED,
+            tier=tier,
+            model_identity=new_identity,
+            cases_total=total,
+            cases_passed=passed,
+            rationale=(f"pass_rate={pass_rate:.3f} < threshold={self._threshold:.2f}"),
+            incident_ticket_id=ticket,
+            flag_set=flag_set,
+            metric_emitted=True,
+        )

--- a/src/services/model_assurance/model_upgrade_watcher/ports.py
+++ b/src/services/model_assurance/model_upgrade_watcher/ports.py
@@ -1,0 +1,79 @@
+"""Ports for the model-upgrade watcher (issue #212).
+
+Each integration boundary is a narrow Protocol so production wires
+boto3-backed implementations and tests use simple fakes. Production
+implementations of these ports live in
+``model_assurance/govcloud/`` and ``model_assurance/audit/`` (existing
+modules); the wiring is a follow-up PR once #212 is merged.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from src.services.model_assurance.model_upgrade_watcher.contracts import (
+    BedrockModelVersion,
+)
+
+
+class BedrockModelRegistryPort(Protocol):
+    """Reports the currently-configured Bedrock model version per tier."""
+
+    def current_versions(self) -> tuple[BedrockModelVersion, ...]:
+        """Return one entry per configured tier."""
+
+
+class RevalidationFlagPort(Protocol):
+    """SSM-backed feature flag that gates DAL A/B auto-promotion."""
+
+    def is_set(self, *, tier: str) -> bool:
+        """Return True iff DAL A/B auto-promotion is currently blocked."""
+
+    def set(self, *, tier: str, reason: str) -> None:
+        """Block DAL A/B auto-promotion for ``tier`` with a stored reason."""
+
+    def clear(self, *, tier: str) -> None:
+        """Unblock DAL A/B auto-promotion for ``tier``."""
+
+
+class OracleRerunPort(Protocol):
+    """Runs the Frozen Reference Oracle's reference cases.
+
+    Returns ``(cases_passed, cases_total)``. The caller decides what
+    threshold counts as "passed" -- the Port stays mechanism-free.
+    """
+
+    def rerun_reference_cases(
+        self, *, tier: str, model_identity: str
+    ) -> tuple[int, int]:
+        """Return ``(cases_passed, cases_total)``."""
+
+
+class HitlIncidentPort(Protocol):
+    """Opens a HITL incident on the existing approval gateway."""
+
+    def open_incident(
+        self,
+        *,
+        tier: str,
+        model_identity: str,
+        cases_passed: int,
+        cases_total: int,
+        rationale: str,
+    ) -> str:
+        """Open an incident; return the ticket id."""
+
+
+class MetricEmitterPort(Protocol):
+    """Emits the ``Aura/ModelAssurance/ConsensusReValidationStatus`` metric."""
+
+    def emit(
+        self,
+        *,
+        tier: str,
+        model_identity: str,
+        status: str,
+        cases_passed: int,
+        cases_total: int,
+    ) -> None:
+        """Emit one metric data point."""

--- a/src/services/model_assurance/model_upgrade_watcher/watcher.py
+++ b/src/services/model_assurance/model_upgrade_watcher/watcher.py
@@ -1,0 +1,72 @@
+"""Bedrock model version watcher (issue #212).
+
+A small, stateful object that the scheduler (production: EventBridge
+Lambda) calls on a cadence. The watcher reads the current model
+versions from the registry, compares against its last snapshot, and
+returns one :class:`ModelUpgradeEvent` per configured tier so the
+coordinator can decide what to do.
+
+Stateful between ticks; the snapshot is in-process. Production deploys
+this as a Lambda warm container; on cold start the watcher reads the
+last-known versions from SSM via a separate restore step (out of
+scope here -- a trivial dict-load).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.services.model_assurance.model_upgrade_watcher.contracts import (
+    BedrockModelVersion,
+    ModelUpgradeEvent,
+)
+from src.services.model_assurance.model_upgrade_watcher.ports import (
+    BedrockModelRegistryPort,
+)
+
+
+class ModelVersionWatcher:
+    """Detect bumps in the registry's reported versions."""
+
+    def __init__(
+        self,
+        *,
+        registry: BedrockModelRegistryPort,
+        initial_snapshot: tuple[BedrockModelVersion, ...] = (),
+    ) -> None:
+        self._registry = registry
+        # tier -> version -- mutable across ticks
+        self._snapshot: dict[str, BedrockModelVersion] = {
+            v.tier: v for v in initial_snapshot
+        }
+
+    def snapshot(self) -> tuple[BedrockModelVersion, ...]:
+        """Return the watcher's last-known versions (one per tier)."""
+        return tuple(self._snapshot.values())
+
+    def tick(self) -> tuple[ModelUpgradeEvent, ...]:
+        """Run one detection pass; return per-tier events.
+
+        Events are emitted for every configured tier, not only the
+        ones that bumped. The caller filters via ``event.is_bump``.
+        That way the audit trail shows we *checked* each tier on
+        every tick.
+        """
+        now = datetime.now(timezone.utc)
+        current = self._registry.current_versions()
+        events: list[ModelUpgradeEvent] = []
+        for cur in current:
+            prev = self._snapshot.get(
+                cur.tier,
+                BedrockModelVersion(tier=cur.tier, model_id="", version=""),
+            )
+            events.append(
+                ModelUpgradeEvent(
+                    detected_at=now,
+                    tier=cur.tier,
+                    previous=prev,
+                    current=cur,
+                )
+            )
+            self._snapshot[cur.tier] = cur
+        return tuple(events)

--- a/tests/services/model_assurance/model_upgrade_watcher/test_model_upgrade_watcher.py
+++ b/tests/services/model_assurance/model_upgrade_watcher/test_model_upgrade_watcher.py
@@ -1,0 +1,363 @@
+"""Tests for the model-upgrade re-validation watcher (issue #212)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+
+from src.services.model_assurance.model_upgrade_watcher import (
+    BedrockModelVersion,
+    ModelVersionWatcher,
+    RevalidationCoordinator,
+    RevalidationStatus,
+)
+
+# =============================================================================
+# Fakes
+# =============================================================================
+
+
+@dataclass
+class _FakeRegistry:
+    versions: tuple[BedrockModelVersion, ...] = ()
+
+    def current_versions(self) -> tuple[BedrockModelVersion, ...]:
+        return self.versions
+
+
+@dataclass
+class _FakeFlag:
+    set_tiers: set[str] = field(default_factory=set)
+    set_reasons: dict[str, str] = field(default_factory=dict)
+    cleared_tiers: list[str] = field(default_factory=list)
+
+    def is_set(self, *, tier: str) -> bool:
+        return tier in self.set_tiers
+
+    def set(self, *, tier: str, reason: str) -> None:
+        self.set_tiers.add(tier)
+        self.set_reasons[tier] = reason
+
+    def clear(self, *, tier: str) -> None:
+        self.set_tiers.discard(tier)
+        self.cleared_tiers.append(tier)
+
+
+@dataclass
+class _FakeOracle:
+    pass_count: int = 380
+    total_count: int = 400
+    raise_for_tier: Optional[str] = None
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    def rerun_reference_cases(
+        self, *, tier: str, model_identity: str
+    ) -> tuple[int, int]:
+        self.calls.append((tier, model_identity))
+        if self.raise_for_tier and tier == self.raise_for_tier:
+            raise RuntimeError("oracle simulated failure")
+        return self.pass_count, self.total_count
+
+
+@dataclass
+class _FakeIncident:
+    opened: list[tuple[str, str, int, int, str]] = field(default_factory=list)
+    next_ticket: int = 1
+
+    def open_incident(
+        self,
+        *,
+        tier: str,
+        model_identity: str,
+        cases_passed: int,
+        cases_total: int,
+        rationale: str,
+    ) -> str:
+        self.opened.append((tier, model_identity, cases_passed, cases_total, rationale))
+        ticket = f"INC-{self.next_ticket}"
+        self.next_ticket += 1
+        return ticket
+
+
+@dataclass
+class _FakeMetric:
+    emitted: list[dict] = field(default_factory=list)
+
+    def emit(
+        self,
+        *,
+        tier: str,
+        model_identity: str,
+        status: str,
+        cases_passed: int,
+        cases_total: int,
+    ) -> None:
+        self.emitted.append(
+            {
+                "tier": tier,
+                "model_identity": model_identity,
+                "status": status,
+                "cases_passed": cases_passed,
+                "cases_total": cases_total,
+            }
+        )
+
+
+# =============================================================================
+# Watcher
+# =============================================================================
+
+
+class TestModelVersionWatcher:
+    def test_no_initial_snapshot_treats_first_tick_as_bump(self):
+        registry = _FakeRegistry(
+            versions=(BedrockModelVersion(tier="STANDARD", model_id="m1"),)
+        )
+        watcher = ModelVersionWatcher(registry=registry)
+        events = watcher.tick()
+        assert len(events) == 1
+        assert events[0].tier == "STANDARD"
+        assert events[0].is_bump is True
+        assert events[0].previous.identity == ""
+
+    def test_same_version_on_next_tick_is_not_a_bump(self):
+        registry = _FakeRegistry(
+            versions=(BedrockModelVersion(tier="STANDARD", model_id="m1"),)
+        )
+        watcher = ModelVersionWatcher(
+            registry=registry,
+            initial_snapshot=(BedrockModelVersion(tier="STANDARD", model_id="m1"),),
+        )
+        events = watcher.tick()
+        assert len(events) == 1
+        assert events[0].is_bump is False
+
+    def test_bump_detected_when_model_id_changes(self):
+        registry = _FakeRegistry(
+            versions=(BedrockModelVersion(tier="STANDARD", model_id="m2"),)
+        )
+        watcher = ModelVersionWatcher(
+            registry=registry,
+            initial_snapshot=(BedrockModelVersion(tier="STANDARD", model_id="m1"),),
+        )
+        events = watcher.tick()
+        assert events[0].is_bump is True
+        assert events[0].previous.identity == "m1"
+        assert events[0].current.identity == "m2"
+
+    def test_bump_detected_when_version_changes_only(self):
+        registry = _FakeRegistry(
+            versions=(
+                BedrockModelVersion(tier="STANDARD", model_id="claude", version="4.7"),
+            )
+        )
+        watcher = ModelVersionWatcher(
+            registry=registry,
+            initial_snapshot=(
+                BedrockModelVersion(tier="STANDARD", model_id="claude", version="4.6"),
+            ),
+        )
+        events = watcher.tick()
+        assert events[0].is_bump is True
+
+
+# =============================================================================
+# Coordinator
+# =============================================================================
+
+
+class TestRevalidationCoordinator:
+    def _make(self, **overrides):
+        flag = overrides.get("flag", _FakeFlag())
+        oracle = overrides.get("oracle", _FakeOracle())
+        incident = overrides.get("incident", _FakeIncident())
+        metric = overrides.get("metric", _FakeMetric())
+        threshold = overrides.get("pass_rate_threshold", 0.95)
+        return (
+            RevalidationCoordinator(
+                flag=flag,
+                oracle=oracle,
+                incident=incident,
+                metric=metric,
+                pass_rate_threshold=threshold,
+            ),
+            flag,
+            oracle,
+            incident,
+            metric,
+        )
+
+    def test_no_bump_results_in_skipped(self):
+        coord, flag, oracle, incident, metric = self._make()
+        events = ModelVersionWatcher(
+            registry=_FakeRegistry(
+                versions=(BedrockModelVersion(tier="STANDARD", model_id="m1"),)
+            ),
+            initial_snapshot=(BedrockModelVersion(tier="STANDARD", model_id="m1"),),
+        ).tick()
+        outcomes = coord.process(events)
+        assert len(outcomes) == 1
+        assert outcomes[0].status == RevalidationStatus.SKIPPED
+        assert flag.set_tiers == set()
+        assert metric.emitted == []
+        assert incident.opened == []
+        assert oracle.calls == []
+
+    def test_bump_pass_clears_flag_and_emits_metric(self):
+        oracle = _FakeOracle(pass_count=390, total_count=400)  # 0.975 > 0.95
+        coord, flag, oracle, incident, metric = self._make(oracle=oracle)
+        events = ModelVersionWatcher(
+            registry=_FakeRegistry(
+                versions=(BedrockModelVersion(tier="STANDARD", model_id="m2"),)
+            ),
+            initial_snapshot=(BedrockModelVersion(tier="STANDARD", model_id="m1"),),
+        ).tick()
+        outcomes = coord.process(events)
+        assert outcomes[0].status == RevalidationStatus.PASSED
+        assert outcomes[0].flag_set is True
+        assert outcomes[0].flag_cleared is True
+        assert outcomes[0].metric_emitted is True
+        assert outcomes[0].incident_ticket_id == ""
+        # Flag was set then cleared.
+        assert "STANDARD" not in flag.set_tiers
+        assert "STANDARD" in flag.cleared_tiers
+        # Metric emitted with PASSED status.
+        assert len(metric.emitted) == 1
+        assert metric.emitted[0]["status"] == "passed"
+        # No incident.
+        assert incident.opened == []
+
+    def test_bump_below_threshold_opens_hitl_incident(self):
+        oracle = _FakeOracle(pass_count=300, total_count=400)  # 0.75 < 0.95
+        coord, flag, oracle, incident, metric = self._make(oracle=oracle)
+        events = ModelVersionWatcher(
+            registry=_FakeRegistry(
+                versions=(BedrockModelVersion(tier="ADVANCED", model_id="m2"),)
+            ),
+            initial_snapshot=(BedrockModelVersion(tier="ADVANCED", model_id="m1"),),
+        ).tick()
+        outcomes = coord.process(events)
+        assert outcomes[0].status == RevalidationStatus.FAILED
+        # Flag stays set.
+        assert "ADVANCED" in flag.set_tiers
+        assert flag.cleared_tiers == []
+        # Incident opened with INC-1.
+        assert len(incident.opened) == 1
+        opened = incident.opened[0]
+        assert opened[0] == "ADVANCED"
+        assert opened[2] == 300
+        assert opened[3] == 400
+        assert outcomes[0].incident_ticket_id == "INC-1"
+        # Metric emitted with FAILED status.
+        assert metric.emitted[0]["status"] == "failed"
+
+    def test_oracle_exception_treated_as_failed(self):
+        oracle = _FakeOracle(raise_for_tier="STANDARD")
+        coord, flag, oracle, incident, metric = self._make(oracle=oracle)
+        events = ModelVersionWatcher(
+            registry=_FakeRegistry(
+                versions=(BedrockModelVersion(tier="STANDARD", model_id="m2"),)
+            ),
+            initial_snapshot=(BedrockModelVersion(tier="STANDARD", model_id="m1"),),
+        ).tick()
+        outcomes = coord.process(events)
+        assert outcomes[0].status == RevalidationStatus.FAILED
+        assert outcomes[0].incident_ticket_id == "INC-1"
+        assert "oracle raised" in outcomes[0].rationale.lower()
+        # Flag stays set.
+        assert "STANDARD" in flag.set_tiers
+
+    def test_multiple_tiers_processed_independently(self):
+        # STANDARD bumps and passes; ADVANCED bumps and fails.
+        registry = _FakeRegistry(
+            versions=(
+                BedrockModelVersion(tier="STANDARD", model_id="s2"),
+                BedrockModelVersion(tier="ADVANCED", model_id="a2"),
+            )
+        )
+        watcher = ModelVersionWatcher(
+            registry=registry,
+            initial_snapshot=(
+                BedrockModelVersion(tier="STANDARD", model_id="s1"),
+                BedrockModelVersion(tier="ADVANCED", model_id="a1"),
+            ),
+        )
+        events = watcher.tick()
+
+        # Use an oracle that fails ADVANCED only.
+        class _SplitOracle:
+            calls: list[str] = []
+
+            def rerun_reference_cases(self, *, tier: str, model_identity: str):
+                self.calls.append(tier)
+                if tier == "ADVANCED":
+                    return 200, 400  # 0.5 < 0.95
+                return 400, 400  # 1.0 >= 0.95
+
+        oracle = _SplitOracle()
+        flag = _FakeFlag()
+        incident = _FakeIncident()
+        metric = _FakeMetric()
+        coord = RevalidationCoordinator(
+            flag=flag, oracle=oracle, incident=incident, metric=metric
+        )
+        outcomes = coord.process(events)
+
+        statuses = {o.tier: o.status for o in outcomes}
+        assert statuses["STANDARD"] == RevalidationStatus.PASSED
+        assert statuses["ADVANCED"] == RevalidationStatus.FAILED
+        # STANDARD: flag set then cleared. ADVANCED: flag stays set + incident.
+        assert "STANDARD" not in flag.set_tiers
+        assert "ADVANCED" in flag.set_tiers
+        assert len(incident.opened) == 1
+        assert incident.opened[0][0] == "ADVANCED"
+        assert len(metric.emitted) == 2
+
+    def test_pass_rate_threshold_validation(self):
+        flag = _FakeFlag()
+        oracle = _FakeOracle()
+        incident = _FakeIncident()
+        metric = _FakeMetric()
+        with pytest.raises(ValueError):
+            RevalidationCoordinator(
+                flag=flag,
+                oracle=oracle,
+                incident=incident,
+                metric=metric,
+                pass_rate_threshold=1.5,
+            )
+        with pytest.raises(ValueError):
+            RevalidationCoordinator(
+                flag=flag,
+                oracle=oracle,
+                incident=incident,
+                metric=metric,
+                pass_rate_threshold=0.0,
+            )
+
+    def test_outcome_audit_dict_shape(self):
+        coord, _flag, _oracle, _incident, _metric = self._make()
+        events = ModelVersionWatcher(
+            registry=_FakeRegistry(
+                versions=(BedrockModelVersion(tier="STANDARD", model_id="m2"),)
+            ),
+            initial_snapshot=(BedrockModelVersion(tier="STANDARD", model_id="m1"),),
+        ).tick()
+        outcomes = coord.process(events)
+        audit = outcomes[0].to_audit_dict()
+        for key in (
+            "status",
+            "tier",
+            "model_identity",
+            "cases_total",
+            "cases_passed",
+            "rationale",
+            "incident_ticket_id",
+            "flag_cleared",
+            "flag_set",
+            "metric_emitted",
+            "completed_at",
+        ):
+            assert key in audit


### PR DESCRIPTION
## Summary

Closes #212. ADR-088 documented a known risk: when AWS bumps a Bedrock model version (e.g. Claude Sonnet 4.6 -> 4.7), the statistical convergence properties of DVE's N-of-M consensus may shift, but nothing in the platform auto-detected the bump or blocked DAL A/B auto-promotion during a re-validation window. This PR closes that gap.

## What ships

- \`ModelVersionWatcher\` -- stateful detector that compares current Bedrock-registered model versions per tier against its last-known snapshot. Emits one \`ModelUpgradeEvent\` per configured tier per tick.
- \`RevalidationCoordinator\` -- composition root that orchestrates the full bump → set flag → re-run Frozen Reference Oracle → clear / escalate lifecycle.
- Five narrow Protocols (registry, flag, oracle, incident, metric) so production wires boto3-backed implementations and tests use fakes.

## Lifecycle per detected bump

1. Set the SSM-backed feature flag for the tier (blocks DAL A/B auto-promotion immediately).
2. Trigger the Frozen Reference Oracle (ADR-088) to re-run its reference cases against the new model.
3. If pass-rate ≥ 0.95 (configurable): clear the flag, emit \`Aura/ModelAssurance/ConsensusReValidationStatus = PASSED\`.
4. If below threshold (or oracle raises): keep the flag set, open a HITL incident on the existing approval gateway, emit \`...= FAILED\`.

## Honest scope

- The Port implementations (boto3 Bedrock listing, SSM parameter put/get, CloudWatch put-metric-data, HITL gateway adapter) are **not** in this PR. They wire up against the existing \`model_assurance/govcloud/\` and \`audit/\` modules in a follow-on once #212 merges. Tests use fakes; the coordinator logic is fully exercised.
- No EventBridge schedule template here either -- that's CFN, separate PR.

## Test plan

- [x] 11 new tests in \`tests/services/model_assurance/model_upgrade_watcher/test_model_upgrade_watcher.py\` covering: snapshot semantics (cold start, no-change, model-id bump, version-only bump), no-bump = SKIPPED, bump + pass clears flag + emits PASSED metric, bump + below-threshold opens HITL + emits FAILED metric, oracle exception treated as FAILED, multi-tier independence (one passes + one fails on the same tick), threshold validation, audit-dict shape.
- [x] Lint clean (black, flake8, isort, bandit).

## Related

- ADR-088 (Continuous Model Assurance) -- parent; Frozen Reference Oracle is the re-run target
- ADR-085 (DVE) -- consumer of the consensus statistics this re-validation protects
- ADR-032 (HITL) -- incident escalation channel
- Issues #209, #210, #211 -- sibling AI-vuln gap closures (one PR each)