### PR TITLE
feat(campaign-manager): #214-S1+S2 -- KMS-backed signing for definition + checkpoint

### DIFF
--- a/src/services/campaign_manager/kms_signing/__init__.py
+++ b/src/services/campaign_manager/kms_signing/__init__.py
@@ -1,0 +1,38 @@
+"""KMS-Sign / Verify abstractions for the campaign manager (issue #214 S1+S2).
+
+Closes the two T1565.001 tampering attacks the Sally review surfaced
+on PR #208:
+
+  - S1: ``CampaignDefinition.definition_signature`` was a free-text
+    field defaulting to ``""``. Anyone with DynamoDB write could
+    mutate ``cost_cap_usd`` / ``approver_quorum`` / ``hitl_milestones``
+    after creation without anything detecting it.
+  - S2: ``PhaseCheckpoint.kms_signature`` accepted any non-empty
+    string via ``_dummy_kms_signature()``. The resume path trusted
+    tampered checkpoints in production.
+
+This module ships the Port + a deterministic HMAC test implementation.
+Production wires a KMS-backed signer through the same Port; that
+implementation lives in ``model_assurance/govcloud/`` and is out of
+scope for this PR.
+"""
+
+from src.services.campaign_manager.kms_signing.canonical import (
+    canonicalize_campaign_definition,
+    canonicalize_phase_checkpoint,
+)
+from src.services.campaign_manager.kms_signing.deterministic import (
+    DeterministicCampaignSigner,
+)
+from src.services.campaign_manager.kms_signing.ports import (
+    CampaignSignerPort,
+    SignatureVerificationError,
+)
+
+__all__ = [
+    "CampaignSignerPort",
+    "DeterministicCampaignSigner",
+    "SignatureVerificationError",
+    "canonicalize_campaign_definition",
+    "canonicalize_phase_checkpoint",
+]

--- a/src/services/campaign_manager/kms_signing/canonical.py
+++ b/src/services/campaign_manager/kms_signing/canonical.py
@@ -1,0 +1,67 @@
+"""Canonical byte serialisation for signing campaign artifacts.
+
+The signature is computed over a JSON-serialised form of the
+artifact that:
+
+  1. Excludes the signature field itself (otherwise the signature
+     would have to include its own hash -- impossible).
+  2. Uses ``sort_keys=True`` so two equivalent dicts produce the
+     same bytes regardless of insertion order.
+  3. Uses a stable representation for ``datetime`` (ISO 8601 with
+     timezone) and ``Enum`` (the value).
+
+Production KMS signing wraps the bytes returned here; the test
+``DeterministicCampaignSigner`` HMACs them.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from enum import Enum
+
+from src.services.campaign_manager.contracts import CampaignDefinition, PhaseCheckpoint
+
+
+def _default(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, set):
+        return sorted(value)
+    if isinstance(value, tuple):
+        return list(value)
+    raise TypeError(f"Cannot canonicalise type {type(value).__name__}")
+
+
+def canonicalize_campaign_definition(definition: CampaignDefinition) -> bytes:
+    """Return the deterministic bytes used to sign a CampaignDefinition.
+
+    Excludes the ``definition_signature`` field (which carries the
+    signature being computed) and ``created_at`` (purely informational;
+    excluding keeps tests deterministic without freezing time).
+    """
+    raw = asdict(definition)
+    raw.pop("definition_signature", None)
+    raw.pop("created_at", None)
+    return json.dumps(
+        raw, default=_default, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def canonicalize_phase_checkpoint(checkpoint: PhaseCheckpoint) -> bytes:
+    """Return the deterministic bytes used to sign a PhaseCheckpoint.
+
+    Excludes ``kms_signature`` and ``created_at`` for the same
+    reasons as above. The artifact manifest, cost counters, and
+    success criteria progress ARE included -- they're load-bearing
+    for tamper detection.
+    """
+    raw = asdict(checkpoint)
+    raw.pop("kms_signature", None)
+    raw.pop("created_at", None)
+    return json.dumps(
+        raw, default=_default, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")

--- a/src/services/campaign_manager/kms_signing/deterministic.py
+++ b/src/services/campaign_manager/kms_signing/deterministic.py
@@ -1,0 +1,57 @@
+"""Deterministic HMAC-SHA256 signer for tests + in-process development.
+
+Production code MUST wire a KMS-backed implementation through the
+same ``CampaignSignerPort`` Protocol. This implementation is
+explicitly **not safe** for production -- it stores keys in process
+memory and uses HMAC (symmetric) rather than asymmetric signing.
+
+The "deterministic" name flags the constraint: HMAC with a fixed key
+produces the same output for the same input, which matches the
+audit-trail requirement on the Port.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import threading
+
+
+class DeterministicCampaignSigner:
+    """In-memory HMAC-SHA256 signer for tests.
+
+    Keys are generated lazily per ``key_id`` and stashed in a process-
+    local dict. Two ``DeterministicCampaignSigner`` instances are
+    **not** interchangeable -- they have distinct key material -- so
+    tests can simulate a key-rotation event by constructing a second
+    instance and watching verification fail.
+    """
+
+    def __init__(self, *, seed: bytes = b"aura-campaign-test-secret") -> None:
+        self._seed = seed
+        self._keys: dict[str, bytes] = {}
+        self._lock = threading.Lock()
+
+    def _key_for(self, key_id: str) -> bytes:
+        with self._lock:
+            cached = self._keys.get(key_id)
+            if cached is not None:
+                return cached
+            derived = hmac.new(
+                self._seed, key_id.encode("utf-8"), hashlib.sha256
+            ).digest()
+            self._keys[key_id] = derived
+            return derived
+
+    def sign(self, *, payload: bytes, key_id: str) -> str:
+        digest = hmac.new(self._key_for(key_id), payload, hashlib.sha256).digest()
+        return base64.b64encode(digest).decode("ascii")
+
+    def verify(self, *, payload: bytes, signature: str, key_id: str) -> bool:
+        try:
+            expected = self.sign(payload=payload, key_id=key_id)
+        except Exception:  # pragma: no cover -- defensive
+            return False
+        # constant-time comparison (HMAC defense).
+        return hmac.compare_digest(expected, signature)

--- a/src/services/campaign_manager/kms_signing/ports.py
+++ b/src/services/campaign_manager/kms_signing/ports.py
@@ -1,0 +1,45 @@
+"""Signer / verifier Port for campaign-manager state objects (issue #214)."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class SignatureVerificationError(Exception):
+    """Raised when a signature does not verify against the payload.
+
+    Distinct from ``TamperedStateError`` (which is raised by the
+    checkpoint store on tamper). This exception is raised by the
+    orchestrator's verification path, with a structured reason
+    string that names the failing artifact (definition vs
+    checkpoint) and the tenant + campaign for forensics.
+    """
+
+
+class CampaignSignerPort(Protocol):
+    """Sign and verify canonical bytes for campaign-state artifacts.
+
+    Implementations MUST be deterministic for a given (payload,
+    key_id) pair so re-signing the same artifact yields the same
+    signature. The deterministic property is required for the
+    audit trail; production KMS-backed signers achieve it via
+    asymmetric Sign (RSASSA_PSS_SHA_256 deterministic mode).
+
+    ``key_id`` is the logical key identifier -- tenant-scoped in
+    production (e.g. ``alias/aura/campaign-signing/<tenant>``). The
+    Port is intentionally string-keyed so test implementations don't
+    have to model the full KMS alias hierarchy.
+    """
+
+    def sign(self, *, payload: bytes, key_id: str) -> str:
+        """Sign ``payload`` and return a base64-encoded signature string."""
+
+    def verify(self, *, payload: bytes, signature: str, key_id: str) -> bool:
+        """Verify ``signature`` against ``payload``. Returns True iff valid.
+
+        Implementations MUST NOT raise on mismatch -- the caller
+        decides how to escalate. Implementations MAY raise on
+        unrecoverable errors (e.g. KMS key revoked or unreachable);
+        the orchestrator translates those to
+        ``SignatureVerificationError``.
+        """

--- a/src/services/campaign_manager/orchestrator.py
+++ b/src/services/campaign_manager/orchestrator.py
@@ -42,7 +42,15 @@ from .exceptions import (
     CostCapExceededError,
     InvalidCampaignDefinitionError,
     SeparationOfDutiesError,
+    TamperedStateError,
     TenantCostCapExceededError,
+)
+from .kms_signing import (
+    CampaignSignerPort,
+    DeterministicCampaignSigner,
+    SignatureVerificationError,
+    canonicalize_campaign_definition,
+    canonicalize_phase_checkpoint,
 )
 from .operation_ledger import OperationLedger
 from .phases.base import CampaignWorker, Phase, PhaseExecutionContext, PhaseResult
@@ -80,6 +88,9 @@ class CampaignOrchestrator:
         operation_ledger: OperationLedger,
         tenant_rollup: TenantCostRollup,
         worker_registry: dict,
+        *,
+        signer: CampaignSignerPort | None = None,
+        require_signed_input: bool = False,
     ) -> None:
         self._state_store = state_store
         self._checkpoint_store = checkpoint_store
@@ -91,6 +102,24 @@ class CampaignOrchestrator:
         # implementation — production wraps cost trackers in a side store
         # so SFN workers can resume after a process restart.
         self._cost_trackers: dict[str, CampaignCostTracker] = {}
+        # #214-S1 + S2: signer + verifier for tamper-detection on
+        # CampaignDefinition and PhaseCheckpoint. Defaults to a
+        # deterministic HMAC implementation for tests and in-process
+        # development; production wires a KMS-backed implementation
+        # through the same Port.
+        #
+        # ``require_signed_input``: when True, the orchestrator rejects
+        # any CampaignDefinition that arrives unsigned. Production sets
+        # this True (the API layer is responsible for signing at the
+        # tenant boundary); the default is False for backward
+        # compatibility with in-process callers that pass unsigned
+        # definitions and rely on the orchestrator to sign them.
+        self._signer: CampaignSignerPort = signer or DeterministicCampaignSigner()
+        self._require_signed_input = require_signed_input
+        # Cache of verified-or-signed definitions so re-verification on
+        # every public-method entry stays O(1) after the first call.
+        # Keyed by ``(tenant_id, campaign_id)`` -> signed definition.
+        self._signed_definitions: dict[tuple[str, str], CampaignDefinition] = {}
 
     # -------------------------------------------------------------------------
     # Campaign creation
@@ -105,9 +134,11 @@ class CampaignOrchestrator:
 
         Validation enforces (a) campaign type is supported by a registered
         worker, (b) approver_quorum meets the type's minimum, (c) tenant
-        cost rollup has headroom, (d) success_criteria is non-empty.
+        cost rollup has headroom, (d) success_criteria is non-empty,
+        (e) signature is present and verifies (#214-S1).
         """
         self._validate_definition(definition)
+        definition = self._ensure_signed_definition(definition)
 
         # D9: tenant cost rollup gate
         if not await self._tenant_rollup.can_start_campaign(
@@ -185,6 +216,10 @@ class CampaignOrchestrator:
         Returns the post-execution state. Callers iterate until the
         returned state's status is terminal or AWAITING_HITL.
         """
+        # #214-S1: re-verify the caller-supplied definition every time;
+        # a mutated definition would otherwise sail past on subsequent
+        # phase invocations.
+        definition = self._ensure_signed_definition(definition)
         state = await self._load_state(definition)
         if state.status.is_terminal:
             return state
@@ -215,6 +250,11 @@ class CampaignOrchestrator:
         prior_checkpoint = await self._checkpoint_store.read(
             definition.campaign_id, phase.definition.phase_id
         )
+        # #214-S2: verify checkpoint signature before trusting it for
+        # resume. Store-level tamper detection is the first line of
+        # defence; signature verification is the second.
+        if prior_checkpoint is not None:
+            self._verify_checkpoint(prior_checkpoint, definition)
         context = PhaseExecutionContext(
             definition=definition,
             state=state,
@@ -265,7 +305,11 @@ class CampaignOrchestrator:
     ) -> CampaignState:
         """Translate a PhaseResult into a state-machine transition."""
         # Persist checkpoint regardless of outcome (resumable on retry).
-        checkpoint = PhaseCheckpoint(
+        # #214-S2: sign with the configured signer over canonical bytes
+        # (excludes ``kms_signature`` + ``created_at``). InMemory store
+        # already rejects empty signatures; production KMS impl returns
+        # an asymmetric signature that the verify path checks on read.
+        unsigned_checkpoint = PhaseCheckpoint(
             campaign_id=definition.campaign_id,
             phase_id=phase.definition.phase_id,
             artifact_manifest=result.artifacts,
@@ -278,8 +322,8 @@ class CampaignOrchestrator:
                 phases_completed=state.clock.phases_completed
                 + (1 if result.advances_state_machine else 0),
             ),
-            kms_signature=_dummy_kms_signature(definition.campaign_id),
         )
+        checkpoint = self._sign_checkpoint(unsigned_checkpoint, definition)
         checkpoint_key = await self._checkpoint_store.write(checkpoint)
 
         completed = CompletedPhaseRef(
@@ -354,6 +398,11 @@ class CampaignOrchestrator:
         campaign's milestones. High-impact campaigns require
         ``approver_quorum >= 2`` distinct approvers.
         """
+        # #214-S1: verify signature before honouring the approval --
+        # an attacker who tampers with the definition to lower
+        # approver_quorum should not be able to walk approvals
+        # through afterward.
+        definition = self._ensure_signed_definition(definition)
         if approver_principal_arn == definition.creator_principal_arn:
             raise SeparationOfDutiesError(
                 f"Principal {approver_principal_arn} created campaign "
@@ -418,6 +467,7 @@ class CampaignOrchestrator:
     # -------------------------------------------------------------------------
 
     async def cancel_campaign(self, definition: CampaignDefinition) -> CampaignState:
+        definition = self._ensure_signed_definition(definition)
         state = await self._load_state(definition)
         if state.status.is_terminal:
             return state
@@ -486,13 +536,123 @@ class CampaignOrchestrator:
         )
         return updated
 
+    # -------------------------------------------------------------------------
+    # #214-S1 + S2: signing + verification helpers
+    # -------------------------------------------------------------------------
 
-def _dummy_kms_signature(campaign_id: str) -> str:
-    """Stub signature for in-process use.
+    @staticmethod
+    def _definition_key_id(tenant_id: str) -> str:
+        """Stable per-tenant key id used by the signer Port.
 
-    Production swaps in a KMS-backed signer; the in-memory checkpoint
-    store accepts any non-empty string. Tests that exercise the
-    tamper-detection path use ``InMemoryCheckpointStore.simulate_tamper``
-    rather than checking signature validity.
-    """
-    return f"unsigned:{campaign_id}"
+        Production maps this to ``alias/aura/campaign-signing/<tenant>``
+        in the KMS-backed implementation.
+        """
+        return f"campaign-signing:{tenant_id}"
+
+    @staticmethod
+    def _checkpoint_key_id(tenant_id: str) -> str:
+        return f"campaign-checkpoint:{tenant_id}"
+
+    def _sign_definition(self, definition: CampaignDefinition) -> CampaignDefinition:
+        """Sign an unsigned definition; return a copy with the signature set."""
+        payload = canonicalize_campaign_definition(definition)
+        signature = self._signer.sign(
+            payload=payload, key_id=self._definition_key_id(definition.tenant_id)
+        )
+        return replace(definition, definition_signature=signature)
+
+    def _verify_definition(self, definition: CampaignDefinition) -> None:
+        """Verify ``definition_signature``; raise on mismatch (#214-S1)."""
+        if not definition.definition_signature:
+            raise SignatureVerificationError(
+                f"CampaignDefinition for tenant={definition.tenant_id} "
+                f"campaign={definition.campaign_id} carries no signature "
+                f"(definition_signature is empty). This is the T1565.001 "
+                f"tampering bypass closed by #214-S1; refuse to operate "
+                f"on unsigned definitions."
+            )
+        ok = False
+        try:
+            ok = self._signer.verify(
+                payload=canonicalize_campaign_definition(definition),
+                signature=definition.definition_signature,
+                key_id=self._definition_key_id(definition.tenant_id),
+            )
+        except Exception as exc:  # pragma: no cover -- KMS-unreachable etc.
+            raise SignatureVerificationError(
+                f"Signature verification raised for tenant={definition.tenant_id} "
+                f"campaign={definition.campaign_id}: {exc}"
+            ) from exc
+        if not ok:
+            raise SignatureVerificationError(
+                f"CampaignDefinition signature does not verify for "
+                f"tenant={definition.tenant_id} "
+                f"campaign={definition.campaign_id}. Definition has been "
+                f"tampered with or signed under a revoked key."
+            )
+
+    def _ensure_signed_definition(
+        self, definition: CampaignDefinition
+    ) -> CampaignDefinition:
+        """Sign-or-verify the definition before use.
+
+        Production behaviour (``require_signed_input=True``): rejects
+        unsigned input and verifies signed input. Test / in-process
+        behaviour (default): signs unsigned input automatically and
+        verifies signed input. The cached signed copy is reused so
+        re-verification on every public-method entry stays cheap.
+        """
+        key = (definition.tenant_id, definition.campaign_id)
+        if definition.definition_signature:
+            self._verify_definition(definition)
+            self._signed_definitions[key] = definition
+            return definition
+        if self._require_signed_input:
+            raise SignatureVerificationError(
+                f"require_signed_input=True but the definition for "
+                f"tenant={definition.tenant_id} "
+                f"campaign={definition.campaign_id} is unsigned. The API "
+                f"layer must sign before calling the orchestrator."
+            )
+        signed = self._sign_definition(definition)
+        self._signed_definitions[key] = signed
+        return signed
+
+    def _sign_checkpoint(
+        self,
+        checkpoint: PhaseCheckpoint,
+        definition: CampaignDefinition,
+    ) -> PhaseCheckpoint:
+        """Return a copy of ``checkpoint`` with a real signature populated."""
+        payload = canonicalize_phase_checkpoint(checkpoint)
+        signature = self._signer.sign(
+            payload=payload,
+            key_id=self._checkpoint_key_id(definition.tenant_id),
+        )
+        return replace(checkpoint, kms_signature=signature)
+
+    def _verify_checkpoint(
+        self,
+        checkpoint: PhaseCheckpoint,
+        definition: CampaignDefinition,
+    ) -> None:
+        """Verify ``checkpoint.kms_signature``; raise on mismatch (#214-S2)."""
+        payload = canonicalize_phase_checkpoint(checkpoint)
+        try:
+            ok = self._signer.verify(
+                payload=payload,
+                signature=checkpoint.kms_signature,
+                key_id=self._checkpoint_key_id(definition.tenant_id),
+            )
+        except Exception as exc:  # pragma: no cover
+            raise TamperedStateError(
+                f"Checkpoint signature verification raised for "
+                f"campaign={checkpoint.campaign_id} "
+                f"phase={checkpoint.phase_id}: {exc}"
+            ) from exc
+        if not ok:
+            raise TamperedStateError(
+                f"Checkpoint signature does not verify for "
+                f"campaign={checkpoint.campaign_id} "
+                f"phase={checkpoint.phase_id}. Refusing to resume."
+            )

--- a/tests/services/campaign_manager/test_issue_214_kms_signing.py
+++ b/tests/services/campaign_manager/test_issue_214_kms_signing.py
@@ -1,0 +1,422 @@
+"""Regression tests for issue #214 S1+S2: KMS signing.
+
+Sally's review surfaced two T1565.001 (Stored Data Manipulation)
+attacks on PR #208:
+
+  - S1: ``CampaignDefinition.definition_signature`` defaulted to ``""``
+    and was never verified. Anyone with DynamoDB write could mutate
+    ``cost_cap_usd``, ``approver_quorum``, or ``hitl_milestones``
+    post-creation.
+  - S2: ``PhaseCheckpoint.kms_signature`` was populated by
+    ``_dummy_kms_signature()`` returning ``"unsigned:<id>"``. The
+    resume path trusted any non-empty string.
+
+These tests must FAIL against the pre-fix code (no signature
+enforcement, dummy signatures) and PASS against the fixed
+implementation. Tests cover positive paths, tamper detection,
+fail-closed semantics for ``require_signed_input``, and the
+canonical-bytes contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import replace
+
+import pytest
+
+from src.services.campaign_manager.checkpoint_store import InMemoryCheckpointStore
+from src.services.campaign_manager.contracts import (
+    CampaignDefinition,
+    CampaignStatus,
+    CampaignType,
+    PhaseCheckpoint,
+)
+from src.services.campaign_manager.exceptions import TamperedStateError
+from src.services.campaign_manager.kms_signing import (
+    DeterministicCampaignSigner,
+    SignatureVerificationError,
+    canonicalize_campaign_definition,
+    canonicalize_phase_checkpoint,
+)
+from src.services.campaign_manager.operation_ledger import InMemoryOperationLedger
+from src.services.campaign_manager.orchestrator import CampaignOrchestrator
+from src.services.campaign_manager.phases.compliance_hardening import (
+    ComplianceHardeningWorker,
+)
+from src.services.campaign_manager.state_store import InMemoryCampaignStateStore
+from src.services.campaign_manager.tenant_cost_rollup import InMemoryTenantCostRollup
+
+# =============================================================================
+# Canonical bytes
+# =============================================================================
+
+
+def _unsigned_definition(**overrides) -> CampaignDefinition:
+    defaults = dict(
+        campaign_id=str(uuid.uuid4()),
+        tenant_id="tenant-sig",
+        campaign_type=CampaignType.COMPLIANCE_HARDENING,
+        target={"repo": "acme/api"},
+        success_criteria={"standard": "NIST-800-53"},
+        cost_cap_usd=200.0,
+        wall_clock_budget_hours=12.0,
+        autonomy_policy_id="policy-conservative",
+        hitl_milestones=("hitl_review",),
+        approver_quorum=2,
+        creator_principal_arn="arn:aws:iam::123:user/alice",
+    )
+    defaults.update(overrides)
+    return CampaignDefinition(**defaults)
+
+
+class TestCanonicalBytes:
+    def test_signature_field_excluded_from_canonical_bytes(self):
+        d1 = _unsigned_definition()
+        d2 = replace(d1, definition_signature="some-other-sig")
+        # Two definitions identical except for the signature must
+        # produce the same canonical bytes (otherwise signing would
+        # be impossible).
+        assert canonicalize_campaign_definition(d1) == canonicalize_campaign_definition(
+            d2
+        )
+
+    def test_field_change_changes_canonical_bytes(self):
+        d1 = _unsigned_definition(cost_cap_usd=100.0)
+        d2 = replace(d1, cost_cap_usd=999.0)
+        assert canonicalize_campaign_definition(d1) != canonicalize_campaign_definition(
+            d2
+        )
+
+    def test_created_at_excluded_from_canonical_bytes(self):
+        # Time-of-creation must not be part of the signed payload --
+        # otherwise tests would fail any time the clock advanced.
+        import datetime
+
+        d1 = _unsigned_definition()
+        d2 = replace(
+            d1, created_at=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc)
+        )
+        assert canonicalize_campaign_definition(d1) == canonicalize_campaign_definition(
+            d2
+        )
+
+    def test_checkpoint_canonical_excludes_signature(self):
+        cp = PhaseCheckpoint(
+            campaign_id="c1",
+            phase_id="p1",
+            artifact_manifest=(),
+            success_criteria_progress=(),
+            phase_summary="done",
+            kms_signature="sig-A",
+        )
+        cp_other_sig = replace(cp, kms_signature="sig-B")
+        assert canonicalize_phase_checkpoint(cp) == canonicalize_phase_checkpoint(
+            cp_other_sig
+        )
+
+
+# =============================================================================
+# DeterministicCampaignSigner
+# =============================================================================
+
+
+class TestDeterministicSigner:
+    def test_sign_then_verify_passes(self):
+        signer = DeterministicCampaignSigner()
+        sig = signer.sign(payload=b"hello", key_id="k1")
+        assert signer.verify(payload=b"hello", signature=sig, key_id="k1")
+
+    def test_modified_payload_fails_verify(self):
+        signer = DeterministicCampaignSigner()
+        sig = signer.sign(payload=b"hello", key_id="k1")
+        assert not signer.verify(payload=b"goodbye", signature=sig, key_id="k1")
+
+    def test_wrong_key_id_fails_verify(self):
+        signer = DeterministicCampaignSigner()
+        sig = signer.sign(payload=b"hello", key_id="k1")
+        assert not signer.verify(payload=b"hello", signature=sig, key_id="k2")
+
+    def test_two_signers_with_different_seeds_disagree(self):
+        a = DeterministicCampaignSigner(seed=b"alpha")
+        b = DeterministicCampaignSigner(seed=b"beta")
+        sig = a.sign(payload=b"x", key_id="k")
+        assert b.verify(payload=b"x", signature=sig, key_id="k") is False
+
+    def test_deterministic_signature(self):
+        signer = DeterministicCampaignSigner()
+        a = signer.sign(payload=b"x", key_id="k")
+        b = signer.sign(payload=b"x", key_id="k")
+        assert a == b
+
+
+# =============================================================================
+# S1: definition signing in the orchestrator
+# =============================================================================
+
+
+@pytest.fixture()
+async def orchestrator_with_default_signer() -> CampaignOrchestrator:
+    rollup = InMemoryTenantCostRollup()
+    await rollup.set_cap("tenant-sig", "2026-05", cap_usd=10_000.0)
+    return CampaignOrchestrator(
+        state_store=InMemoryCampaignStateStore(),
+        checkpoint_store=InMemoryCheckpointStore(),
+        operation_ledger=InMemoryOperationLedger(),
+        tenant_rollup=rollup,
+        worker_registry={
+            CampaignType.COMPLIANCE_HARDENING: ComplianceHardeningWorker()
+        },
+    )
+
+
+class TestS1DefinitionSignature:
+    @pytest.mark.asyncio
+    async def test_unsigned_definition_is_signed_by_default(
+        self, orchestrator_with_default_signer
+    ):
+        orch = orchestrator_with_default_signer
+        unsigned = _unsigned_definition()
+        assert unsigned.definition_signature == ""
+        state = await orch.create_campaign(unsigned, "2026-05")
+        # Orchestrator stored a signed copy internally.
+        signed = orch._signed_definitions[(unsigned.tenant_id, unsigned.campaign_id)]
+        assert signed.definition_signature != ""
+        assert state.status == CampaignStatus.CREATED
+
+    @pytest.mark.asyncio
+    async def test_tampered_definition_is_rejected_on_next_call(
+        self, orchestrator_with_default_signer
+    ):
+        orch = orchestrator_with_default_signer
+        unsigned = _unsigned_definition()
+        await orch.create_campaign(unsigned, "2026-05")
+        signed = orch._signed_definitions[(unsigned.tenant_id, unsigned.campaign_id)]
+        # An attacker mutates cost_cap_usd, keeping the old signature.
+        tampered = replace(signed, cost_cap_usd=1_000_000.0)
+        with pytest.raises(SignatureVerificationError, match="does not verify"):
+            await orch.run_next_phase(tampered)
+
+    @pytest.mark.asyncio
+    async def test_tampered_quorum_is_rejected(self, orchestrator_with_default_signer):
+        orch = orchestrator_with_default_signer
+        unsigned = _unsigned_definition()
+        await orch.create_campaign(unsigned, "2026-05")
+        signed = orch._signed_definitions[(unsigned.tenant_id, unsigned.campaign_id)]
+        # Attacker lowers approver_quorum from 2 to 1 to skip co-approval.
+        tampered = replace(signed, approver_quorum=1)
+        with pytest.raises(SignatureVerificationError):
+            await orch.approve_milestone(
+                tampered, approver_principal_arn="arn:aws:iam::123:user/bob"
+            )
+
+    @pytest.mark.asyncio
+    async def test_signed_definition_round_trips(
+        self, orchestrator_with_default_signer
+    ):
+        orch = orchestrator_with_default_signer
+        unsigned = _unsigned_definition()
+        # External pre-sign (production-shape: API layer signs).
+        pre_signed = orch._sign_definition(unsigned)
+        state = await orch.create_campaign(pre_signed, "2026-05")
+        assert state.status == CampaignStatus.CREATED
+        # Now run a phase using the externally-signed definition.
+        state = await orch.run_next_phase(pre_signed)
+        assert state.status != CampaignStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_require_signed_input_rejects_unsigned(self):
+        rollup = InMemoryTenantCostRollup()
+        await rollup.set_cap("tenant-sig", "2026-05", cap_usd=10_000.0)
+        orch = CampaignOrchestrator(
+            state_store=InMemoryCampaignStateStore(),
+            checkpoint_store=InMemoryCheckpointStore(),
+            operation_ledger=InMemoryOperationLedger(),
+            tenant_rollup=rollup,
+            worker_registry={
+                CampaignType.COMPLIANCE_HARDENING: ComplianceHardeningWorker()
+            },
+            require_signed_input=True,
+        )
+        unsigned = _unsigned_definition()
+        with pytest.raises(SignatureVerificationError, match="API layer must sign"):
+            await orch.create_campaign(unsigned, "2026-05")
+
+    @pytest.mark.asyncio
+    async def test_require_signed_input_accepts_pre_signed(self):
+        rollup = InMemoryTenantCostRollup()
+        await rollup.set_cap("tenant-sig", "2026-05", cap_usd=10_000.0)
+        signer = DeterministicCampaignSigner()
+        orch = CampaignOrchestrator(
+            state_store=InMemoryCampaignStateStore(),
+            checkpoint_store=InMemoryCheckpointStore(),
+            operation_ledger=InMemoryOperationLedger(),
+            tenant_rollup=rollup,
+            worker_registry={
+                CampaignType.COMPLIANCE_HARDENING: ComplianceHardeningWorker()
+            },
+            signer=signer,
+            require_signed_input=True,
+        )
+        unsigned = _unsigned_definition()
+        # Sign with the same signer the orchestrator was given.
+        signed = orch._sign_definition(unsigned)
+        state = await orch.create_campaign(signed, "2026-05")
+        assert state.status == CampaignStatus.CREATED
+
+
+# =============================================================================
+# S2: checkpoint signing in the orchestrator
+# =============================================================================
+
+
+class TestS2CheckpointSignature:
+    @pytest.mark.asyncio
+    async def test_checkpoint_carries_real_signature_not_dummy(
+        self, orchestrator_with_default_signer
+    ):
+        orch = orchestrator_with_default_signer
+        store: InMemoryCheckpointStore = orch._checkpoint_store  # type: ignore[assignment]
+        unsigned = _unsigned_definition()
+        await orch.create_campaign(unsigned, "2026-05")
+        await orch.run_next_phase(unsigned)
+        # The first phase (baseline_scan) wrote a checkpoint.
+        cp = await store.read(unsigned.campaign_id, "baseline_scan")
+        assert cp is not None
+        assert cp.kms_signature != ""
+        # The pre-fix _dummy_kms_signature returned 'unsigned:<id>'.
+        assert not cp.kms_signature.startswith("unsigned:")
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_verifies_on_resume(
+        self, orchestrator_with_default_signer
+    ):
+        orch = orchestrator_with_default_signer
+        unsigned = _unsigned_definition()
+        await orch.create_campaign(unsigned, "2026-05")
+        # Drive past the first phase so a checkpoint exists.
+        state = await orch.run_next_phase(unsigned)
+        assert state.status != CampaignStatus.FAILED
+        # Subsequent run_next_phase reads + verifies the prior checkpoint.
+        # Should NOT raise.
+        state2 = await orch.run_next_phase(unsigned)
+        assert state2.status != CampaignStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_tampered_checkpoint_raises_on_verify(
+        self, orchestrator_with_default_signer
+    ):
+        # The orchestrator's resume path only reads the current phase's
+        # prior checkpoint (used for retry / resume within the same
+        # phase). To exercise the tamper-detection contract without
+        # adding a retry-from-failed path to the state machine, call
+        # the verifier directly on a tampered checkpoint -- this is
+        # the exact code path the orchestrator runs after every
+        # checkpoint_store.read().
+        orch = orchestrator_with_default_signer
+        store: InMemoryCheckpointStore = orch._checkpoint_store  # type: ignore[assignment]
+        unsigned = _unsigned_definition()
+        await orch.create_campaign(unsigned, "2026-05")
+        await orch.run_next_phase(unsigned)
+        # Read the stored checkpoint, tamper with phase_summary while
+        # keeping the old signature.
+        original = await store.read(unsigned.campaign_id, "baseline_scan")
+        assert original is not None
+        tampered = replace(original, phase_summary="MALICIOUS REPLACEMENT")
+        signed_def = orch._signed_definitions[
+            (unsigned.tenant_id, unsigned.campaign_id)
+        ]
+        with pytest.raises(TamperedStateError, match="does not verify"):
+            orch._verify_checkpoint(tampered, signed_def)
+
+    @pytest.mark.asyncio
+    async def test_tampered_checkpoint_with_pristine_signature_still_verifies(
+        self, orchestrator_with_default_signer
+    ):
+        # Sanity check: an UN-tampered checkpoint must verify cleanly.
+        orch = orchestrator_with_default_signer
+        store: InMemoryCheckpointStore = orch._checkpoint_store  # type: ignore[assignment]
+        unsigned = _unsigned_definition()
+        await orch.create_campaign(unsigned, "2026-05")
+        await orch.run_next_phase(unsigned)
+        cp = await store.read(unsigned.campaign_id, "baseline_scan")
+        assert cp is not None
+        signed_def = orch._signed_definitions[
+            (unsigned.tenant_id, unsigned.campaign_id)
+        ]
+        # Should NOT raise.
+        orch._verify_checkpoint(cp, signed_def)
+
+    @pytest.mark.asyncio
+    async def test_signer_rotation_invalidates_old_checkpoints(self):
+        # Two signers with distinct seeds simulate a key rotation.
+        rollup = InMemoryTenantCostRollup()
+        await rollup.set_cap("tenant-sig", "2026-05", cap_usd=10_000.0)
+        old_signer = DeterministicCampaignSigner(seed=b"old-key")
+        store = InMemoryCheckpointStore()
+        ledger = InMemoryOperationLedger()
+        state_store = InMemoryCampaignStateStore()
+
+        orch_old = CampaignOrchestrator(
+            state_store=state_store,
+            checkpoint_store=store,
+            operation_ledger=ledger,
+            tenant_rollup=rollup,
+            worker_registry={
+                CampaignType.COMPLIANCE_HARDENING: ComplianceHardeningWorker()
+            },
+            signer=old_signer,
+        )
+        unsigned = _unsigned_definition()
+        signed = orch_old._sign_definition(unsigned)
+        await orch_old.create_campaign(signed, "2026-05")
+        await orch_old.run_next_phase(signed)
+        # A new orchestrator with a different key tries to resume.
+        new_signer = DeterministicCampaignSigner(seed=b"new-key")
+        orch_new = CampaignOrchestrator(
+            state_store=state_store,
+            checkpoint_store=store,
+            operation_ledger=ledger,
+            tenant_rollup=rollup,
+            worker_registry={
+                CampaignType.COMPLIANCE_HARDENING: ComplianceHardeningWorker()
+            },
+            signer=new_signer,
+        )
+        # Verification of the existing signed definition under the new
+        # key fails (T1565: definition path is the first wall).
+        with pytest.raises(SignatureVerificationError):
+            await orch_new.run_next_phase(signed)
+
+
+# =============================================================================
+# Backward compatibility -- the 42 original tests must still pass
+# (covered by running the full suite; this is a smoke test).
+# =============================================================================
+
+
+class TestBackwardCompatibility:
+    @pytest.mark.asyncio
+    async def test_unsigned_definitions_still_work_in_legacy_mode(
+        self, orchestrator_with_default_signer
+    ):
+        # The 42 pre-existing tests pass unsigned definitions to the
+        # orchestrator. Default require_signed_input=False auto-signs
+        # them so those tests keep passing without modification.
+        orch = orchestrator_with_default_signer
+        unsigned = _unsigned_definition()
+        await orch.create_campaign(unsigned, "2026-05")
+        bob = "arn:aws:iam::123:user/bob"
+        carol = "arn:aws:iam::123:user/carol"
+        for _ in range(40):
+            state = await orch.run_next_phase(unsigned)
+            if state.status == CampaignStatus.AWAITING_HITL:
+                await orch.approve_milestone(unsigned, approver_principal_arn=bob)
+                state = await orch.approve_milestone(
+                    unsigned, approver_principal_arn=carol
+                )
+                continue
+            if state.status.is_terminal:
+                break
+        assert state.status == CampaignStatus.COMPLETED


### PR DESCRIPTION
## Summary

Closes #214 Phase 2 items **S1 and S2**. Sally's three-agent review of PR #208 surfaced two T1565.001 (Stored Data Manipulation) attacks that this PR closes.

- **S1**: \`CampaignDefinition.definition_signature\` was a free-text field defaulting to empty and never verified -- anyone with DynamoDB write could mutate \`cost_cap_usd\`, \`approver_quorum\`, or \`hitl_milestones\` after creation. NIST 800-53 AU-10 non-repudiation blocker.
- **S2**: \`PhaseCheckpoint.kms_signature\` was populated by \`_dummy_kms_signature()\` returning \`\"unsigned:<id>\"\`. The resume path trusted any non-empty string.

## Architecture

- **\`CampaignSignerPort\`** -- narrow Protocol with \`sign()\` + \`verify()\`. Production wires KMS asymmetric Sign (RSASSA_PSS_SHA_256 deterministic) through this Port; test implementations use HMAC.
- **\`DeterministicCampaignSigner\`** -- HMAC-SHA256 with per-key-id derivation from a process-local seed; constant-time compare in verify. Explicitly not safe for production (documented in the docstring).
- **\`canonicalize_campaign_definition\` / \`canonicalize_phase_checkpoint\`** -- deterministic JSON bytes excluding the signature field and \`created_at\` (so signing is possible and tests are clock-independent).

## Orchestrator wiring

- New \`signer\` + \`require_signed_input\` constructor params. Defaults preserve backward compat with the 42 existing tests; production sets \`require_signed_input=True\` and the API layer signs at the tenant boundary.
- \`_ensure_signed_definition\` is called at the top of \`create_campaign\`, \`run_next_phase\`, \`approve_milestone\`, and \`cancel_campaign\`. A mutated definition can no longer sail past on subsequent invocations.
- \`_apply_phase_result\` signs checkpoints with the real signer over canonical bytes; \`_dummy_kms_signature\` deleted.
- After every \`checkpoint_store.read\`, the orchestrator verifies the signature before trusting it.

Tamper attempts raise \`SignatureVerificationError\` (definition) or \`TamperedStateError\` (checkpoint).

## Honest scope

- Production KMS-backed signer Port implementation lives in \`model_assurance/govcloud/\` as a separate follow-up. This PR ships the abstraction + test implementation only.
- The \`require_signed_input=False\` default is a deliberate bridge for the 42 pre-existing tests. The API layer must flip it to True in production -- documented in the orchestrator constructor docstring.
- Two-person rule hardening (S3), cap-as-DoS defence (S4), op-ledger tenant scoping (S5), and Mythos SIEM emit (S6) remain open under #214.

## Test plan

- [x] 21 new tests in \`tests/services/campaign_manager/test_issue_214_kms_signing.py\`: canonical-bytes contract (sig + created_at excluded, field changes detected), deterministic signer round-trip + rotation, S1 tamper detection on \`cost_cap_usd\` + \`approver_quorum\`, S1 fail-closed when \`require_signed_input=True\` with unsigned input, S2 real signature populated + verified on resume, S2 tamper detection on checkpoint fields.
- [x] 42 pre-existing campaign-manager tests continue to pass via the auto-sign bridge.
- [x] 63 total campaign-manager tests pass in 0.32s.
- [x] Lint clean (black, flake8, isort, bandit).

## Related

- ADR-089 (Long-Horizon Security Campaigns) -- parent
- Issue #214 -- Phase 2 (security required revisions); this PR closes S1 + S2
- PR #208 -- ADR-089 phases 1-4+6 (the implementation Sally reviewed)
- ADR-088 (Continuous Model Assurance) -- production KMS signer Port impl lives in this package