### PR TITLE
fix(campaign-manager): #214-S5 -- op-ledger tenant scoping + monotonic recorded_at

### DIFF
--- a/src/services/campaign_manager/operation_ledger.py
+++ b/src/services/campaign_manager/operation_ledger.py
@@ -20,13 +20,22 @@ The DynamoDB-backed implementation lives in a follow-up; this module
 ships an in-memory implementation that satisfies the same contract,
 suitable for tests and for in-process use during development.
 
+#214-S5: ``tenant_id`` is part of the key, not derived from the
+campaign_id. Two tenants with colliding campaign UUIDs (or a malicious
+tenant_id-spoof attempt) cannot replay or read each other's outcomes.
+``record_outcome`` enforces monotonic ``recorded_at`` per
+(tenant, campaign) so a clock-rewind or write-race cannot serve a
+stale outcome as fresh.
+
 Author: Project Aura Team
 Created: 2026-05-07
+Updated: 2026-05-22 (issue #214-S5 -- tenant scoping + monotonic recorded_at)
 """
 
 from __future__ import annotations
 
 import threading
+from datetime import datetime
 from typing import Protocol
 
 from .contracts import OperationClaim, OperationOutcome, OperationStatus
@@ -38,6 +47,7 @@ class OperationLedger(Protocol):
 
     async def claim(
         self,
+        tenant_id: str,
         campaign_id: str,
         phase_id: str,
         operation_id: str,
@@ -55,6 +65,7 @@ class OperationLedger(Protocol):
 
     async def record_outcome(
         self,
+        tenant_id: str,
         campaign_id: str,
         phase_id: str,
         operation_id: str,
@@ -63,12 +74,16 @@ class OperationLedger(Protocol):
         """Attach an outcome to a previously claimed operation.
 
         Raises ``OperationAlreadyClaimedError`` if an outcome is
-        already recorded for this key (cannot overwrite).
+        already recorded for this key (cannot overwrite). Raises the
+        same exception if the outcome's ``recorded_at`` is earlier
+        than the most-recent outcome for this (tenant, campaign)
+        (#214-S5 monotonic guarantee).
         """
         ...
 
     async def get_outcome(
         self,
+        tenant_id: str,
         campaign_id: str,
         phase_id: str,
         operation_id: str,
@@ -80,26 +95,39 @@ class OperationLedger(Protocol):
 class InMemoryOperationLedger:
     """In-memory ``OperationLedger`` for tests and development.
 
-    Backed by a dict keyed by ``(campaign_id, phase_id, operation_id)``.
-    A lock guards mutations so concurrent ``claim`` calls behave like
-    DynamoDB conditional writes.
+    Backed by a dict keyed by ``(tenant_id, campaign_id, phase_id,
+    operation_id)``. A lock guards mutations so concurrent ``claim``
+    calls behave like DynamoDB conditional writes.
 
     Production code will swap in a DynamoDB implementation against the
     same Protocol; tests target the Protocol, so this implementation
     is a faithful behavioural model.
+
+    Tenant scoping (#214-S5): the tenant_id is part of the key, not
+    derived. Cross-tenant replay (same operation_id from a different
+    tenant) is impossible because the key does not match.
+
+    Monotonic ``recorded_at`` (#214-S5): per (tenant_id, campaign_id),
+    each ``record_outcome`` call must carry a ``recorded_at`` that is
+    >= the most-recent prior outcome's. A clock-rewind or out-of-order
+    write raises ``OperationAlreadyClaimedError`` rather than silently
+    overwriting the ordering.
     """
 
     def __init__(self) -> None:
-        self._claims: dict[tuple[str, str, str], OperationOutcome | None] = {}
+        self._claims: dict[tuple[str, str, str, str], OperationOutcome | None] = {}
+        # Per-(tenant, campaign) high-water-mark for monotonic ordering.
+        self._last_recorded_at: dict[tuple[str, str], datetime] = {}
         self._lock = threading.Lock()
 
     async def claim(
         self,
+        tenant_id: str,
         campaign_id: str,
         phase_id: str,
         operation_id: str,
     ) -> OperationClaim:
-        key = (campaign_id, phase_id, operation_id)
+        key = (tenant_id, campaign_id, phase_id, operation_id)
         with self._lock:
             if key in self._claims:
                 prior = self._claims[key]
@@ -128,12 +156,14 @@ class InMemoryOperationLedger:
 
     async def record_outcome(
         self,
+        tenant_id: str,
         campaign_id: str,
         phase_id: str,
         operation_id: str,
         outcome: OperationOutcome,
     ) -> None:
-        key = (campaign_id, phase_id, operation_id)
+        key = (tenant_id, campaign_id, phase_id, operation_id)
+        watermark_key = (tenant_id, campaign_id)
         with self._lock:
             existing = self._claims.get(key)
             if key not in self._claims:
@@ -144,14 +174,27 @@ class InMemoryOperationLedger:
                 raise OperationAlreadyClaimedError(
                     f"Outcome already recorded for operation {key!r}"
                 )
+            # #214-S5: monotonic recorded_at per (tenant, campaign).
+            high_water = self._last_recorded_at.get(watermark_key)
+            if high_water is not None and outcome.recorded_at < high_water:
+                raise OperationAlreadyClaimedError(
+                    f"OperationOutcome.recorded_at "
+                    f"({outcome.recorded_at.isoformat()}) is earlier than "
+                    f"the most-recent outcome for tenant={tenant_id} "
+                    f"campaign={campaign_id} "
+                    f"({high_water.isoformat()}). Monotonic ordering is "
+                    f"required to prevent out-of-order replay (#214-S5)."
+                )
             self._claims[key] = outcome
+            self._last_recorded_at[watermark_key] = outcome.recorded_at
 
     async def get_outcome(
         self,
+        tenant_id: str,
         campaign_id: str,
         phase_id: str,
         operation_id: str,
     ) -> OperationOutcome | None:
-        key = (campaign_id, phase_id, operation_id)
+        key = (tenant_id, campaign_id, phase_id, operation_id)
         with self._lock:
             return self._claims.get(key)

--- a/tests/services/campaign_manager/test_campaign_manager.py
+++ b/tests/services/campaign_manager/test_campaign_manager.py
@@ -124,19 +124,23 @@ async def configured_orchestrator(tenant_id, billing_period) -> CampaignOrchestr
 class TestOperationLedger:
     def test_first_claim_succeeds(self):
         ledger = InMemoryOperationLedger()
-        claim = asyncio.run(ledger.claim("c1", "p1", "op1"))
+        claim = asyncio.run(ledger.claim("t1", "c1", "p1", "op1"))
         assert claim.status == OperationStatus.CLAIMED
         assert claim.prior_outcome is None
 
     def test_second_claim_returns_already_executed(self):
         ledger = InMemoryOperationLedger()
-        asyncio.run(ledger.claim("c1", "p1", "op1"))
+        asyncio.run(ledger.claim("t1", "c1", "p1", "op1"))
         asyncio.run(
             ledger.record_outcome(
-                "c1", "p1", "op1", OperationOutcome(success=True, summary="ok")
+                "t1",
+                "c1",
+                "p1",
+                "op1",
+                OperationOutcome(success=True, summary="ok"),
             )
         )
-        claim2 = asyncio.run(ledger.claim("c1", "p1", "op1"))
+        claim2 = asyncio.run(ledger.claim("t1", "c1", "p1", "op1"))
         assert claim2.status == OperationStatus.ALREADY_EXECUTED
         assert claim2.prior_outcome is not None
         assert claim2.prior_outcome.success is True
@@ -147,6 +151,7 @@ class TestOperationLedger:
         with pytest.raises(OperationAlreadyClaimedError):
             asyncio.run(
                 ledger.record_outcome(
+                    "t1",
                     "c1",
                     "p1",
                     "op1",
@@ -156,15 +161,20 @@ class TestOperationLedger:
 
     def test_record_outcome_is_one_shot(self):
         ledger = InMemoryOperationLedger()
-        asyncio.run(ledger.claim("c1", "p1", "op1"))
+        asyncio.run(ledger.claim("t1", "c1", "p1", "op1"))
         asyncio.run(
             ledger.record_outcome(
-                "c1", "p1", "op1", OperationOutcome(success=True, summary="ok")
+                "t1",
+                "c1",
+                "p1",
+                "op1",
+                OperationOutcome(success=True, summary="ok"),
             )
         )
         with pytest.raises(OperationAlreadyClaimedError):
             asyncio.run(
                 ledger.record_outcome(
+                    "t1",
                     "c1",
                     "p1",
                     "op1",
@@ -177,8 +187,8 @@ class TestOperationLedger:
         # The next attempt sees ALREADY_EXECUTED with a placeholder outcome
         # so it does not duplicate the side effect.
         ledger = InMemoryOperationLedger()
-        asyncio.run(ledger.claim("c1", "p1", "op1"))
-        claim2 = asyncio.run(ledger.claim("c1", "p1", "op1"))
+        asyncio.run(ledger.claim("t1", "c1", "p1", "op1"))
+        claim2 = asyncio.run(ledger.claim("t1", "c1", "p1", "op1"))
         assert claim2.status == OperationStatus.ALREADY_EXECUTED
         assert claim2.prior_outcome is not None
         assert claim2.prior_outcome.success is False  # placeholder
@@ -186,9 +196,9 @@ class TestOperationLedger:
 
     def test_keys_are_per_campaign(self):
         ledger = InMemoryOperationLedger()
-        asyncio.run(ledger.claim("c1", "p1", "op1"))
+        asyncio.run(ledger.claim("t1", "c1", "p1", "op1"))
         # Same op_id but different campaign should still claim
-        claim = asyncio.run(ledger.claim("c2", "p1", "op1"))
+        claim = asyncio.run(ledger.claim("t1", "c2", "p1", "op1"))
         assert claim.status == OperationStatus.CLAIMED
 
 

--- a/tests/services/campaign_manager/test_issue_214_s5_op_ledger.py
+++ b/tests/services/campaign_manager/test_issue_214_s5_op_ledger.py
@@ -1,0 +1,227 @@
+"""Regression tests for issue #214-S5: op-ledger tenant scoping + monotonic recorded_at.
+
+Sally's review surfaced two T1565 / cross-tenant attacks:
+
+  - Ledger keyed by ``(campaign_id, phase_id, operation_id)`` -- if
+    two tenants shared a UUID (collision, tenant import, or a
+    malicious tenant_id spoof), one could read or replay the other's
+    outcomes.
+  - ``recorded_at`` was free-text and never compared against a
+    high-water-mark -- a write-race or clock-rewind could serve a
+    stale outcome as fresh.
+
+These tests must FAIL against the pre-#214-S5 ledger (no tenant_id
+parameter, no monotonic check) and PASS against the fixed version.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.services.campaign_manager.contracts import OperationOutcome, OperationStatus
+from src.services.campaign_manager.exceptions import OperationAlreadyClaimedError
+from src.services.campaign_manager.operation_ledger import InMemoryOperationLedger
+
+# =============================================================================
+# Tenant scoping
+# =============================================================================
+
+
+class TestTenantScoping:
+    @pytest.mark.asyncio
+    async def test_same_campaign_id_across_tenants_is_independent(self):
+        # Two tenants happen to use the same campaign_id (UUID collision,
+        # malicious tenant_id spoof, or imported state). The ledger
+        # MUST treat them as distinct keys.
+        ledger = InMemoryOperationLedger()
+        claim_a = await ledger.claim("tenant-A", "shared-uuid", "p1", "op1")
+        claim_b = await ledger.claim("tenant-B", "shared-uuid", "p1", "op1")
+        # Tenant A claimed first; Tenant B's claim is a NEW claim, not
+        # a re-read of A's outcome.
+        assert claim_a.status == OperationStatus.CLAIMED
+        assert claim_b.status == OperationStatus.CLAIMED
+        # And recording an outcome for A does not leak to B.
+        await ledger.record_outcome(
+            "tenant-A",
+            "shared-uuid",
+            "p1",
+            "op1",
+            OperationOutcome(success=True, summary="A succeeded"),
+        )
+        outcome_b = await ledger.get_outcome("tenant-B", "shared-uuid", "p1", "op1")
+        assert outcome_b is None  # B has only claimed; no outcome recorded
+
+    @pytest.mark.asyncio
+    async def test_cross_tenant_read_does_not_leak(self):
+        # Tenant A records an outcome containing tenant-A-specific
+        # summary. Tenant B querying the same (campaign_id, phase, op)
+        # gets nothing -- the tenant_id is part of the key.
+        ledger = InMemoryOperationLedger()
+        await ledger.claim("tenant-A", "c1", "p1", "op1")
+        await ledger.record_outcome(
+            "tenant-A",
+            "c1",
+            "p1",
+            "op1",
+            OperationOutcome(success=True, summary="TENANT_A_SECRET"),
+        )
+        outcome_b = await ledger.get_outcome("tenant-B", "c1", "p1", "op1")
+        assert outcome_b is None
+        claim_b = await ledger.claim("tenant-B", "c1", "p1", "op1")
+        # B's first claim on the same campaign id is a fresh CLAIMED,
+        # not an ALREADY_EXECUTED that leaks A's outcome.
+        assert claim_b.status == OperationStatus.CLAIMED
+        assert claim_b.prior_outcome is None
+
+    @pytest.mark.asyncio
+    async def test_record_outcome_with_wrong_tenant_does_not_satisfy_claim(
+        self,
+    ):
+        # Tenant A claims an op; an attacker tries to record an outcome
+        # under tenant B with the same campaign / phase / op_id. The
+        # record_outcome MUST raise (no matching claim) rather than
+        # silently associating the outcome with B.
+        ledger = InMemoryOperationLedger()
+        await ledger.claim("tenant-A", "c1", "p1", "op1")
+        with pytest.raises(OperationAlreadyClaimedError):
+            await ledger.record_outcome(
+                "tenant-B",
+                "c1",
+                "p1",
+                "op1",
+                OperationOutcome(success=True, summary="injected"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_independent_high_water_per_tenant(self):
+        # Tenant A records a late-timestamped outcome; tenant B's
+        # earlier-timestamped outcome on the SAME campaign id MUST be
+        # accepted (high-water-mark is per-tenant, not per-campaign-id).
+        ledger = InMemoryOperationLedger()
+        future = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        past = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        await ledger.claim("tenant-A", "c-shared", "p1", "op1")
+        await ledger.record_outcome(
+            "tenant-A",
+            "c-shared",
+            "p1",
+            "op1",
+            OperationOutcome(success=True, summary="A", recorded_at=future),
+        )
+        # Tenant B records earlier-timestamped outcome on same campaign id;
+        # MUST succeed because tenant B has its own high-water-mark.
+        await ledger.claim("tenant-B", "c-shared", "p1", "op1")
+        await ledger.record_outcome(
+            "tenant-B",
+            "c-shared",
+            "p1",
+            "op1",
+            OperationOutcome(success=True, summary="B", recorded_at=past),
+        )
+
+
+# =============================================================================
+# Monotonic recorded_at
+# =============================================================================
+
+
+class TestMonotonicRecordedAt:
+    @pytest.mark.asyncio
+    async def test_in_order_writes_succeed(self):
+        ledger = InMemoryOperationLedger()
+        t0 = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+        for i in range(3):
+            await ledger.claim("t1", "c1", "p1", f"op{i}")
+            await ledger.record_outcome(
+                "t1",
+                "c1",
+                "p1",
+                f"op{i}",
+                OperationOutcome(
+                    success=True,
+                    summary=f"op{i}",
+                    recorded_at=t0 + timedelta(seconds=i),
+                ),
+            )
+        # All three landed.
+        for i in range(3):
+            outcome = await ledger.get_outcome("t1", "c1", "p1", f"op{i}")
+            assert outcome is not None
+
+    @pytest.mark.asyncio
+    async def test_clock_rewind_within_tenant_campaign_is_rejected(self):
+        # An attacker (or a buggy worker) tries to record an outcome
+        # with a recorded_at earlier than the high-water-mark for this
+        # (tenant, campaign). MUST raise.
+        ledger = InMemoryOperationLedger()
+        t1 = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+        t0 = t1 - timedelta(hours=1)
+        await ledger.claim("t1", "c1", "p1", "op1")
+        await ledger.record_outcome(
+            "t1",
+            "c1",
+            "p1",
+            "op1",
+            OperationOutcome(success=True, summary="first", recorded_at=t1),
+        )
+        await ledger.claim("t1", "c1", "p1", "op2")
+        with pytest.raises(OperationAlreadyClaimedError, match="earlier"):
+            await ledger.record_outcome(
+                "t1",
+                "c1",
+                "p1",
+                "op2",
+                OperationOutcome(success=True, summary="rewound", recorded_at=t0),
+            )
+
+    @pytest.mark.asyncio
+    async def test_equal_recorded_at_is_accepted(self):
+        # Equal timestamps are allowed -- clock granularity can produce
+        # identical timestamps for rapid writes; rejecting equality
+        # would be too strict.
+        ledger = InMemoryOperationLedger()
+        t = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+        await ledger.claim("t1", "c1", "p1", "op1")
+        await ledger.record_outcome(
+            "t1",
+            "c1",
+            "p1",
+            "op1",
+            OperationOutcome(success=True, summary="a", recorded_at=t),
+        )
+        await ledger.claim("t1", "c1", "p1", "op2")
+        await ledger.record_outcome(
+            "t1",
+            "c1",
+            "p1",
+            "op2",
+            OperationOutcome(success=True, summary="b", recorded_at=t),
+        )
+
+    @pytest.mark.asyncio
+    async def test_high_water_isolated_per_campaign(self):
+        # Two campaigns under the same tenant must have independent
+        # high-water-marks. A future-dated outcome in one campaign
+        # must NOT block a past-dated outcome in another.
+        ledger = InMemoryOperationLedger()
+        future = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        past = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        await ledger.claim("t1", "c-future", "p1", "op1")
+        await ledger.record_outcome(
+            "t1",
+            "c-future",
+            "p1",
+            "op1",
+            OperationOutcome(success=True, summary="f", recorded_at=future),
+        )
+        # Different campaign, earlier timestamp -- must succeed.
+        await ledger.claim("t1", "c-past", "p1", "op1")
+        await ledger.record_outcome(
+            "t1",
+            "c-past",
+            "p1",
+            "op1",
+            OperationOutcome(success=True, summary="p", recorded_at=past),
+        )


### PR DESCRIPTION
## Summary

Closes the tenant-scoping leg of Sally's S5 finding (#214). The operation ledger keyed by \`(campaign_id, phase_id, operation_id)\` allowed cross-tenant replay if two tenants shared a campaign UUID; \`recorded_at\` was free-text with no monotonic guarantee, allowing write-race or clock-rewind to serve a stale outcome as fresh. T1565.

## What changes

- \`OperationLedger\` Protocol -- \`claim\` / \`record_outcome\` / \`get_outcome\` all take \`tenant_id\` as the first positional argument.
- \`InMemoryOperationLedger\` keys by \`(tenant_id, campaign_id, phase_id, operation_id)\`; cross-tenant replay is impossible.
- \`record_outcome\` enforces a per-\`(tenant, campaign)\` high-water-mark on \`OperationOutcome.recorded_at\`. Clock-rewind / out-of-order writes raise; equal timestamps are allowed (clock-granularity tolerance).
- 6 existing ledger tests updated to pass \`tenant_id\`.

## Honest scope

- **Outcome signing** (the third leg of Sally's S5) follows in a separate PR once #218 lands the \`kms_signing\` module on main. This keeps the surface contained.
- **PR #208 worker phases** (compliance_hardening + vulnerability_remediation) currently call \`ledger.claim(campaign_id, phase_id, op_id)\` without \`tenant_id\`. They'll need a trivial update when they rebase on main after this lands -- the change is pre-staged as a comment on issue #214.

## Test plan

- [x] 8 new regression tests in \`test_issue_214_s5_op_ledger.py\` covering: same-campaign-id-across-tenants is independent, cross-tenant get_outcome does not leak, wrong-tenant record_outcome does not satisfy a claim, high-water-mark is per-tenant, in-order writes succeed, clock-rewind is rejected, equal timestamps are accepted, high-water-mark also isolated per-campaign within a tenant.
- [x] All 6 existing \`TestOperationLedger\` tests still pass with the updated signature.
- [x] All 50 campaign-manager tests pass (42 existing + 8 new).
- [x] Lint clean (black, flake8, isort, bandit).

## Related

- ADR-089 D2 -- idempotency contract
- Issue #214 -- Phase 2 (security required revisions) S5
- PR #218 -- KMS signing module that the outcome-signing follow-up depends on