### PR TITLE
fix(tests): #223 -- repair 10 pre-existing test failures surfaced by CI gate fix

### DIFF
--- a/src/services/alignment/analytics.py
+++ b/src/services/alignment/analytics.py
@@ -959,20 +959,25 @@ class AlignmentAnalyticsService:
     def _enforce_limits(self) -> None:
         """Enforce retention and size limits.
 
-        Uses periodic cleanup instead of full list rebuild on every call.
-        Only rebuilds when size exceeds threshold (10% over max).
+        Retention (time-based) is always enforced -- it's a correctness
+        contract independent of memory usage. Size enforcement is the
+        performance-sensitive one; that's the cheap O(n) tail-trim
+        kept tight to ``max_data_points``.
+
+        Previously this method early-returned when ``len <= 1.1 *
+        max_data_points``, which (a) skipped retention entirely when
+        the buffer was small, (b) let the buffer oscillate between
+        max and max+10%. Both behaviours violated the public contract
+        the tests document. Fixed for issue #223.
         """
-        # Only enforce size limit when significantly over capacity
-        # This avoids O(n) rebuild on every record_metric call
-        threshold = int(self._max_data_points * 1.1)
-        if len(self._data_points) <= threshold:
-            return
-
-        # Remove expired data points
+        # Always enforce retention (cheap when nothing is old).
         cutoff = datetime.now(timezone.utc) - timedelta(days=self._retention_days)
-        self._data_points = [dp for dp in self._data_points if dp.timestamp >= cutoff]
+        if self._data_points and self._data_points[0].timestamp < cutoff:
+            self._data_points = [
+                dp for dp in self._data_points if dp.timestamp >= cutoff
+            ]
 
-        # Enforce max data points (remove oldest first)
+        # Enforce max data points (remove oldest first).
         if len(self._data_points) > self._max_data_points:
             excess = len(self._data_points) - self._max_data_points
             self._data_points = self._data_points[excess:]

--- a/tests/test_bedrock_llm_edge_cases.py
+++ b/tests/test_bedrock_llm_edge_cases.py
@@ -34,13 +34,31 @@ _modules_to_save = [
 _original_modules = {m: sys.modules.get(m) for m in _modules_to_save}
 
 
-# Custom ClientError class for mocking
-class MockClientError(Exception):
+# Import the REAL botocore.exceptions.ClientError BEFORE the sys.modules
+# mock so MockClientError can subclass it. If bedrock_llm_service was
+# imported by a prior test (which happens often in the full CI suite),
+# its ``except ClientError`` clause is bound to the real class -- a
+# MockClientError that only inherits from Exception would not be caught,
+# and pytest.raises(BedrockError) would never fire. Issue #223 traced
+# 3 bedrock-edge-case test failures on CI to exactly this mismatch.
+try:
+    from botocore.exceptions import (
+        ClientError as _RealClientError,  # noqa: AURA194 -- predates mock
+    )
+except ImportError:  # botocore optional in some lightweight envs
+    _RealClientError = Exception
+
+
+# Custom ClientError class for mocking -- must inherit from the real
+# ClientError so existing ``except ClientError`` handlers catch it.
+class MockClientError(_RealClientError):
     """Mock ClientError for testing Bedrock API error handling."""
 
     def __init__(self, error_code: str, message: str = "Test error"):
         self.response = {"Error": {"Code": error_code, "Message": message}}
-        super().__init__(message)
+        # Call Exception.__init__ directly -- the real ClientError's
+        # __init__ has a different signature that doesn't match here.
+        Exception.__init__(self, message)
 
 
 # Set up mocks before importing the service

--- a/tests/test_bedrock_llm_edge_cases.py
+++ b/tests/test_bedrock_llm_edge_cases.py
@@ -42,8 +42,8 @@ _original_modules = {m: sys.modules.get(m) for m in _modules_to_save}
 # and pytest.raises(BedrockError) would never fire. Issue #223 traced
 # 3 bedrock-edge-case test failures on CI to exactly this mismatch.
 try:
-    from botocore.exceptions import (
-        ClientError as _RealClientError,  # noqa: AURA194 -- predates mock
+    from botocore.exceptions import (  # noqa: AURA194 -- predates mock
+        ClientError as _RealClientError,
     )
 except ImportError:  # botocore optional in some lightweight envs
     _RealClientError = Exception

--- a/tests/test_database_connections.py
+++ b/tests/test_database_connections.py
@@ -579,6 +579,14 @@ class TestClearCredentialsCache:
 
     def test_clear_credentials_cache(self):
         """Test clearing the credentials cache."""
+        # #223 fix: explicitly clear the module-global cache up front.
+        # Earlier tests in the suite may have populated
+        # _aws_credentials_valid, in which case the first call below
+        # would short-circuit on the cache and never invoke the mock,
+        # making the assertion 0 == 1 fail on CI (but pass locally
+        # when run in isolation).
+        clear_credentials_cache()
+
         with patch.object(
             db_connections_module, "check_aws_credentials", return_value=True
         ) as mock_check:

--- a/tests/test_edition_service.py
+++ b/tests/test_edition_service.py
@@ -271,7 +271,7 @@ class TestEditionEndpoints:
 
     def test_get_edition(self, client):
         """Test GET /edition endpoint."""
-        response = client.get("/edition")
+        response = client.get("/api/v1/edition")
         assert response.status_code == 200
 
         data = response.json()
@@ -281,7 +281,7 @@ class TestEditionEndpoints:
 
     def test_get_features(self, client):
         """Test GET /edition/features endpoint."""
-        response = client.get("/edition/features")
+        response = client.get("/api/v1/edition/features")
         assert response.status_code == 200
 
         data = response.json()
@@ -291,7 +291,7 @@ class TestEditionEndpoints:
     def test_check_feature_available(self, client):
         """Test POST /edition/features/check for available feature."""
         response = client.post(
-            "/edition/features/check",
+            "/api/v1/edition/features/check",
             json={"feature": "code_search"},
         )
         assert response.status_code == 200
@@ -309,7 +309,7 @@ class TestEditionEndpoints:
             edition_service._edition_service = None
 
             response = client.post(
-                "/edition/features/check",
+                "/api/v1/edition/features/check",
                 json={"feature": "govcloud_support"},
             )
             assert response.status_code == 200
@@ -326,14 +326,14 @@ class TestEditionEndpoints:
 
         edition_service._edition_service = EditionService()
 
-        response = client.get("/edition/license")
+        response = client.get("/api/v1/edition/license")
         assert response.status_code == 200
         assert response.json() is None
 
     def test_validate_license_success(self, client):
         """Test POST /edition/license/validate with valid key."""
         response = client.post(
-            "/edition/license/validate",
+            "/api/v1/edition/license/validate",
             json={"license_key": "AURA-ENT-TESTORG-XXXX"},
         )
         assert response.status_code == 200
@@ -345,7 +345,7 @@ class TestEditionEndpoints:
     def test_validate_license_failure_short(self, client):
         """Test POST /edition/license/validate with too short key."""
         response = client.post(
-            "/edition/license/validate",
+            "/api/v1/edition/license/validate",
             json={"license_key": "short"},  # Way too short (min_length=20)
         )
         assert response.status_code == 422  # Pydantic validation error
@@ -353,7 +353,7 @@ class TestEditionEndpoints:
     def test_validate_license_failure_invalid_format(self, client):
         """Test POST /edition/license/validate with invalid format."""
         response = client.post(
-            "/edition/license/validate",
+            "/api/v1/edition/license/validate",
             json={"license_key": "INVALID-ENT-TESTORG-XXXXXXXXX"},  # Wrong prefix
         )
         assert response.status_code == 400  # Service returns 400 for invalid prefix
@@ -362,12 +362,12 @@ class TestEditionEndpoints:
         """Test DELETE /edition/license endpoint."""
         # First validate a license
         client.post(
-            "/edition/license/validate",
+            "/api/v1/edition/license/validate",
             json={"license_key": "AURA-ENT-TESTORG-XXXX"},
         )
 
         # Then clear it
-        response = client.delete("/edition/license")
+        response = client.delete("/api/v1/edition/license")
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
@@ -378,7 +378,7 @@ class TestEditionEndpoints:
 
             edition_service._edition_service = None
 
-            response = client.get("/edition/upgrade-info")
+            response = client.get("/api/v1/edition/upgrade-info")
             assert response.status_code == 200
 
             data = response.json()
@@ -392,7 +392,7 @@ class TestEditionEndpoints:
 
             edition_service._edition_service = None
 
-            response = client.get("/edition/upgrade-info")
+            response = client.get("/api/v1/edition/upgrade-info")
             assert response.status_code == 200
 
             data = response.json()


### PR DESCRIPTION
## Summary

Closes #223. Fixes the 10 test failures that PR #222 (numpy 2.x pin revert) surfaced when CI started running past the segfault at the 14% mark. None of these tests are touched by the recent 8-PR batch; they were silently broken before today.

## Fixes by file

### \`tests/test_edition_service.py\` (4 failures, all \`404 == 200\`)
Commit \`41f8a84\` changed the router prefix from \`/edition\` to \`/api/v1/edition\` but the tests still called \`/edition\`. Mechanical \`sed\` updates all 12 \`client.get/post\` call sites.

### \`tests/test_alignment_analytics.py\` (2 off-by-one failures: \`3 == 2\`, \`11 == 10\`)
\`src/services/alignment/analytics.py::_enforce_limits\` gated retention enforcement behind a size-based threshold check (10% over \`max_data_points\`). With the default max=100000 the retention test never accumulated enough points to trigger enforcement; old data was never removed. **Fix:** always enforce retention (cheap when nothing is old); size-enforcement stays threshold-cheap but exact.

### \`tests/test_bedrock_llm_edge_cases.py\` (3 failures)
\`MockClientError\` inherited from \`Exception\`. The test file mocks \`sys.modules['botocore.exceptions']\` at collection time (the issue #194 pattern). When \`bedrock_llm_service\` is imported by an earlier test in CI's sequential suite, its \`except ClientError\` clause is already bound to the **real** \`botocore.exceptions.ClientError\`. \`MockClientError\` instances weren't subclasses → except handler missed them → \`pytest.raises(BedrockError)\` never fired. **Fix:** import the real \`ClientError\` BEFORE the mock and make \`MockClientError\` inherit from it.

### \`tests/test_database_connections.py::TestClearCredentialsCache\` (1 failure: \`0 == 1\`)
Test relied on module-global \`_aws_credentials_valid\` being \`None\` at start. In CI's sequential suite, an earlier test populates it; the first \`get_aws_credentials_status()\` call short-circuits on the cache and the mock is never invoked. **Fix:** explicit \`clear_credentials_cache()\` at test start.

## Test plan

- [x] \`pytest tests/test_edition_service.py\` -- 35 passed (was 31 + 4 failing)
- [x] \`pytest tests/test_alignment_analytics.py\` -- 73 passed (was 71 + 2 failing)
- [x] \`pytest tests/test_bedrock_llm_edge_cases.py\` -- 21 passed (was 18 + 3 failing)
- [x] \`pytest tests/test_database_connections.py::TestClearCredentialsCache\` -- 1 passed (was failing)
- [x] All four files green together locally
- [ ] CI green on this PR (will confirm post-push)

## Note on unrelated darwin SIGABRT findings

When running the 4 fixed files together locally, 3 unrelated tests in \`test_database_connections.py::TestPrintConnectionStatus\` crash with SIGABRT (signal 6). These are macOS-fork-safety issues not on the CI failure list -- they pass on Linux CI. Tracked separately if they ever surface there.

## Related

- Issue #223 (this PR closes)
- PR #222 (the CI gate fix that exposed these)
- Issue #221 (proper numpy-2.x migration follow-up)