### PR TITLE
fix(tests): #223 wave 4 -- Qualys XML leaf-text + environment_endpoints User.sub

### DIFF
--- a/src/services/qualys_connector.py
+++ b/src/services/qualys_connector.py
@@ -225,8 +225,16 @@ class QualysConnector(ExternalToolConnector):
             logger.error(f"Failed to parse XML: {e}")
             return {"error": str(e), "raw": xml_text[:500]}
 
-    def _element_to_dict(self, element: ET.Element) -> dict[str, Any]:
-        """Convert XML element to dictionary."""
+    def _element_to_dict(self, element: ET.Element) -> Any:
+        """Convert XML element to dict (or plain string for leaf-text elements).
+
+        Leaf elements containing only text return the string directly so
+        downstream Qualys-response navigation (``.get("TITLE", "")``,
+        ``int(.get("SEVERITY", 1))``, etc.) continues to work. Elements
+        with children OR attributes return a dict; mixed content uses
+        ``#text`` for the inline text alongside child keys.
+        Issue #223 wave 4.
+        """
         result: dict[str, Any] = {}
 
         # Add element attributes
@@ -246,14 +254,17 @@ class QualysConnector(ExternalToolConnector):
                 result[child.tag] = child_data
 
         # Add text content
-        if element.text and element.text.strip():
+        text = element.text.strip() if element.text else ""
+        if text:
             if result:
-                result["#text"] = element.text.strip()
+                # Mixed content -- text alongside children/attributes.
+                result["#text"] = text
             else:
-                # Return dict with text content to maintain consistent return type
-                return {"#text": element.text.strip()}
+                # Pure leaf -- return the string directly so downstream
+                # ``.get("FIELD", "")`` consumers get a string, not a dict.
+                return text
 
-        return result if result else {}
+        return result
 
     # =========================================================================
     # Vulnerability Knowledge Base

--- a/tests/test_environment_endpoints.py
+++ b/tests/test_environment_endpoints.py
@@ -37,12 +37,23 @@ if platform.system() != "Linux":
 
 @pytest.fixture
 def mock_user():
-    """Create a mock authenticated user."""
+    """Create a mock authenticated user.
+
+    The User model in src/api/auth.py uses ``sub`` (Cognito user id),
+    not ``user_id`` -- endpoints route on ``user.sub`` and
+    ``user.groups``. Issue #223 wave 4 fix: align the mock with the
+    real model so Pydantic V2's tightened str-type validation accepts
+    the response payload (previously the endpoint passed
+    ``MagicMock().sub`` -- an unset attribute returning a MagicMock --
+    into Pydantic, which V1 coerced but V2 rejects).
+    """
     user = MagicMock()
-    user.user_id = "user-123"
+    user.sub = "user-123"
+    user.user_id = "user-123"  # retained for tests that reference both
     user.organization_id = "org-456"
     user.email = "test@example.com"
     user.is_admin = False
+    user.groups = []
     return user
 
 
@@ -50,10 +61,12 @@ def mock_user():
 def admin_user():
     """Create a mock admin user."""
     user = MagicMock()
+    user.sub = "admin-001"
     user.user_id = "admin-001"
     user.organization_id = "org-456"
     user.email = "admin@example.com"
     user.is_admin = True
+    user.groups = ["admin"]
     return user
 
 


### PR DESCRIPTION
## Summary

Wave 4 of #223 -- 10 more pre-existing test failures surfaced after PR #224 (wave 3) merged. Two real bugs:

### 1. \`tests/test_enterprise_connectors.py::TestQualysConnector::test_xml_parsing\` (1)

\`src/services/qualys_connector.py::_element_to_dict\` was self-inconsistent: leaf elements with text returned \`{'#text': 'Success'}\` (dict) while downstream callers throughout the same file consume those values as strings (\`int(.get('SEVERITY', 1))\`, \`.get('TITLE', '')\`).

**Fix:** leaf elements return the string directly. Mixed-content elements (children + inline text) still get \`#text\` alongside child keys -- preserved. Return type widened to \`Any\`.

### 2. \`tests/test_environment_endpoints.py\` (9 Pydantic ValidationError)

\`src/api/auth.py::User\` uses \`sub\` (Cognito user id). The test fixture \`mock_user\` set \`user.user_id\` but not \`user.sub\` -- endpoints route on \`user.sub\`. Pydantic V1 coerced \`MagicMock().sub\` to a string silently; V2 rejects it with \`Input should be a valid string\`.

**Fix:** \`mock_user\` and \`admin_user\` now set the canonical \`user.sub\` + \`user.groups\` (list, so the \`'admin' not in user.groups\` membership check in some endpoints works); retain \`user.user_id\` for tests that reference the alias.

## Test plan

- [x] \`pytest tests/test_enterprise_connectors.py::TestQualysConnector\` -- 12 passed
- [x] \`pytest tests/test_environment_endpoints.py\` -- 26 passed (was 17 + 9 failing)
- [x] Lint clean (pre-commit)

## Wave 5 expected

CI \`--maxfail=10\` will surface more once this lands. The whack-a-mole pattern continues. Tracked in #223.

## Related

- Issue #223 (this PR closes wave 4)
- PR #224 (wave 3 -- merged)
- PR #222 (CI gate root-fix -- merged)
- Issue #221 (numpy 2.x migration follow-up)