### PR TITLE
fix(tests): #223 wave 8 -- test_orchestrator_dispatcher TestAutonomyConfiguration

### DIFF
--- a/tests/test_orchestrator_dispatcher.py
+++ b/tests/test_orchestrator_dispatcher.py
@@ -126,29 +126,39 @@ def lambda_context():
 
 
 class TestAutonomyConfiguration:
-    """Tests for autonomy decision logic."""
+    """Tests for autonomy decision logic.
 
-    def test_should_auto_remediate_low_severity_dev(self, mock_aws_clients):
+    These tests exercise the pure-function autonomy gates
+    (``_should_auto_remediate`` / ``_should_require_hitl``) which only
+    depend on ``ENVIRONMENT`` and the autonomy_config dict. They do NOT
+    touch AWS, so the ``mock_aws_clients`` fixture is deliberately not
+    used here -- referencing it caused ``AttributeError`` on Linux CI
+    because the dispatcher module moved to lazy-init getters under
+    issue #466 and no longer exposes module-level ``dynamodb`` /
+    ``dynamodb_client`` / ``eks_client`` / ``sqs_client`` attributes.
+    """
+
+    def test_should_auto_remediate_low_severity_dev(self):
         """Test auto-remediate is enabled for low severity in dev."""
         with patch(f"{MODULE_PATH}.ENVIRONMENT", "dev"):
             assert dispatcher._should_auto_remediate("low", {}) is True
             assert dispatcher._should_auto_remediate("medium", {}) is True
             assert dispatcher._should_auto_remediate("info", {}) is True
 
-    def test_should_not_auto_remediate_high_severity_dev(self, mock_aws_clients):
+    def test_should_not_auto_remediate_high_severity_dev(self):
         """Test auto-remediate is disabled for high severity in dev."""
         with patch(f"{MODULE_PATH}.ENVIRONMENT", "dev"):
             assert dispatcher._should_auto_remediate("high", {}) is False
             assert dispatcher._should_auto_remediate("critical", {}) is False
 
-    def test_should_not_auto_remediate_in_prod(self, mock_aws_clients):
+    def test_should_not_auto_remediate_in_prod(self):
         """Test auto-remediate is always disabled in prod."""
         with patch(f"{MODULE_PATH}.ENVIRONMENT", "prod"):
             assert dispatcher._should_auto_remediate("low", {}) is False
             assert dispatcher._should_auto_remediate("medium", {}) is False
             assert dispatcher._should_auto_remediate("high", {}) is False
 
-    def test_should_auto_remediate_respects_config_override(self, mock_aws_clients):
+    def test_should_auto_remediate_respects_config_override(self):
         """Test auto-remediate respects explicit config."""
         with patch(f"{MODULE_PATH}.ENVIRONMENT", "dev"):
             # Explicit override to disable
@@ -162,7 +172,7 @@ class TestAutonomyConfiguration:
                 is True
             )
 
-    def test_should_require_hitl_in_prod(self, mock_aws_clients):
+    def test_should_require_hitl_in_prod(self):
         """Test HITL is always required in prod."""
         with patch(f"{MODULE_PATH}.ENVIRONMENT", "prod"):
             assert dispatcher._should_require_hitl("low", {}) is True
@@ -170,19 +180,19 @@ class TestAutonomyConfiguration:
             assert dispatcher._should_require_hitl("high", {}) is True
             assert dispatcher._should_require_hitl("critical", {}) is True
 
-    def test_should_require_hitl_high_severity_dev(self, mock_aws_clients):
+    def test_should_require_hitl_high_severity_dev(self):
         """Test HITL is required for high/critical in dev."""
         with patch(f"{MODULE_PATH}.ENVIRONMENT", "dev"):
             assert dispatcher._should_require_hitl("high", {}) is True
             assert dispatcher._should_require_hitl("critical", {}) is True
 
-    def test_should_not_require_hitl_low_severity_dev(self, mock_aws_clients):
+    def test_should_not_require_hitl_low_severity_dev(self):
         """Test HITL is not required for low/medium in dev."""
         with patch(f"{MODULE_PATH}.ENVIRONMENT", "dev"):
             assert dispatcher._should_require_hitl("low", {}) is False
             assert dispatcher._should_require_hitl("medium", {}) is False
 
-    def test_should_require_hitl_respects_config_override(self, mock_aws_clients):
+    def test_should_require_hitl_respects_config_override(self):
         """Test HITL respects explicit config."""
         with patch(f"{MODULE_PATH}.ENVIRONMENT", "dev"):
             # Explicit override to require


### PR DESCRIPTION
## Summary

**Root cause:** `tests/test_orchestrator_dispatcher.py::TestAutonomyConfiguration` errored during fixture setup on Linux CI with:

```
AttributeError: <module 'src.lambda.orchestrator_dispatcher'> does not have the attribute 'dynamodb'
```

The dispatcher module was refactored under issue #466 to use lazy-init AWS-client getter functions (`get_dynamodb_client()`, `get_dynamodb_resource()`, etc.) instead of module-level globals (`dynamodb`, `dynamodb_client`, `eks_client`, `sqs_client`). The `mock_aws_clients` fixture still tries to `patch(f"{MODULE_PATH}.dynamodb")` -- those attributes no longer exist on the module, so `unittest.mock` raises `AttributeError` at fixture entry.

**Fix:** The autonomy tests don't actually need AWS mocks. `_should_auto_remediate` and `_should_require_hitl` are pure functions reading only `ENVIRONMENT` and the `autonomy_config` dict. The fix removes the unused `mock_aws_clients` fixture parameter from all eight tests in `TestAutonomyConfiguration` (the five listed in #223 plus the three that would have failed the same way had CI not stopped at `--maxfail=10`). No production code touched.

Other test classes in the file (`TestDeploymentMode`, `TestLambdaHandler`, `TestEKSDispatch`) genuinely depend on the broken fixture and are out of scope for this wave -- they will need a separate pass to migrate to patching the lazy getters.

## Test plan

- [x] `pytest tests/test_orchestrator_dispatcher.py::TestAutonomyConfiguration --no-cov -p no:cacheprovider --tb=short` -- all 8 pass locally on macOS (Darwin 25.3.0, Python 3.12)
- [x] `pre-commit run --files tests/test_orchestrator_dispatcher.py` -- clean (black + isort applied no changes; trailing whitespace + EOF + don't-commit-to-branch all pass)
- [ ] CI Linux runner: previously erroring 5 (likely 8) cases now pass
- [ ] No regression in other tests that use `mock_aws_clients` (they were already broken under the same root cause; not in scope)