### PR TITLE
fix(tests): #223 wave 8 -- test_opensearch_vector_service

### DIFF
--- a/tests/test_opensearch_vector_service.py
+++ b/tests/test_opensearch_vector_service.py
@@ -9,6 +9,7 @@ Target: 85% coverage of src/services/opensearch_vector_service.py
 
 import os
 import platform
+from collections.abc import MutableMapping
 
 import pytest
 
@@ -40,7 +41,10 @@ class TestOpenSearchVectorService:
         assert service.vector_dimension == 1024
         assert service.use_iam_auth is True
         assert isinstance(service.mock_index, dict)
-        assert isinstance(service.query_cache, dict)
+        # query_cache is a dict when cachetools is unavailable, otherwise a
+        # cachetools.TTLCache (MutableMapping but not a dict subclass). Use
+        # MutableMapping for polymorphic checking across both paths.
+        assert isinstance(service.query_cache, MutableMapping)
 
     def test_initialization_custom_config(self):
         """Test service initialization with custom configuration."""
@@ -1145,11 +1149,31 @@ class TestOpenSearchCacheManagement:
         """Test that cache is pruned when limit is exceeded."""
         service = OpenSearchVectorService(mode=OpenSearchMode.MOCK)
 
-        # Temporarily set a very low cache limit for testing
+        # Temporarily set a very low cache limit for testing. We also need
+        # to rebuild service.query_cache so its internal maxsize reflects
+        # the new class-level limit -- TTLCache captures maxsize at
+        # construction time and a plain dict has no built-in cap, so the
+        # cache instance created in __init__ would otherwise hold all 10
+        # entries on the CACHETOOLS_AVAILABLE Linux CI path.
         original_limit = OpenSearchVectorService.MAX_QUERY_CACHE_SIZE
         OpenSearchVectorService.MAX_QUERY_CACHE_SIZE = 5
 
         try:
+            # Reset the cache instance so its capacity matches the lowered
+            # class-level constant (and so _enforce_cache_limit() prunes
+            # the dict-mode fallback correctly).
+            from src.services.opensearch_vector_service import CACHETOOLS_AVAILABLE
+
+            if CACHETOOLS_AVAILABLE:
+                from cachetools import TTLCache
+
+                service.query_cache = TTLCache(
+                    maxsize=OpenSearchVectorService.MAX_QUERY_CACHE_SIZE,
+                    ttl=OpenSearchVectorService.QUERY_CACHE_TTL_SECONDS,
+                )
+            else:
+                service.query_cache = {}
+
             # Add many entries to exceed the limit
             for i in range(10):
                 # Create unique search queries to populate cache


### PR DESCRIPTION
## Summary

Fixes two CI-only (Linux) failures in tests/test_opensearch_vector_service.py that passed on macOS but failed on Linux runners:

- TestOpenSearchVectorService::test_initialization_mock_mode -- isinstance(service.query_cache, dict) failed on Linux because cachetools is installed there and the service initialises a cachetools.TTLCache (a MutableMapping, not a dict subclass). Switched to MutableMapping so the check is polymorphic across the cachetools-available and dict-fallback paths.
- TestOpenSearchCacheManagement::test_cache_limit_enforcement -- the test lowers MAX_QUERY_CACHE_SIZE to 5 to force pruning, but the TTLCache instance created in __init__ already captured maxsize=1000 at construction time. Class-attribute mutation does not retroactively shrink TTLCache.maxsize, so all 10 inserted entries were retained (10 <= 5 failed). Added a reset that rebuilds service.query_cache against the lowered limit for both the TTLCache and dict-fallback paths.

Production code in src/services/opensearch_vector_service.py is unchanged; both fixes are scoped to the test file.

## Test plan

- Both target tests pass locally on macOS (forked) and the fix is verified to work on the Linux non-forked path.
- pre-commit run --files tests/test_opensearch_vector_service.py is clean.
- CI Linux run will confirm both tests pass under the non-forked code path.
