### PR TITLE
fix(tests): resume main-branch test-rot cleanup (waves 1-4b)

### DIFF
--- a/src/services/scheduling/models.py
+++ b/src/services/scheduling/models.py
@@ -7,7 +7,7 @@ ADR-055: Agent Scheduling View and Job Queue Management
 
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -81,25 +81,14 @@ class ScheduleJobRequest:
             errors.append("scheduled_at must be in the future")
 
         # Max 30 days in the future
-        max_future = now.replace(day=now.day + 30) if now.day <= 1 else now
-        try:
-            from datetime import timedelta
-
-            max_future = now + timedelta(days=30)
-            if self.scheduled_at > max_future:
-                errors.append("scheduled_at cannot be more than 30 days in the future")
-        except Exception:
-            pass
+        max_future = now + timedelta(days=30)
+        if self.scheduled_at > max_future:
+            errors.append("scheduled_at cannot be more than 30 days in the future")
 
         # Min 5 minutes in the future
-        try:
-            from datetime import timedelta
-
-            min_future = now + timedelta(minutes=5)
-            if self.scheduled_at < min_future:
-                errors.append("scheduled_at must be at least 5 minutes in the future")
-        except Exception:
-            pass
+        min_future = now + timedelta(minutes=5)
+        if self.scheduled_at < min_future:
+            errors.append("scheduled_at must be at least 5 minutes in the future")
 
         return errors
 
@@ -192,8 +181,6 @@ class ScheduledJob:
             item["error_message"] = self.error_message
 
         # TTL: 30 days after scheduled time
-        from datetime import timedelta
-
         ttl_time = self.scheduled_at + timedelta(days=30)
         item["ttl"] = int(ttl_time.timestamp())
 

--- a/src/services/ssr/failure_analyzer.py
+++ b/src/services/ssr/failure_analyzer.py
@@ -564,7 +564,12 @@ class FailureAnalyzer:
         for module in import_match:
             suggestions.append(f"Module: {module}")
 
-        return list(set(suggestions))[:5]
+        # dict.fromkeys preserves first-seen order while deduping; plain
+        # set() does not, so the [:5] slice would drop a random suggestion
+        # depending on PYTHONHASHSEED -- which made
+        # test_suggest_context_for_api_misuse flaky / hash-randomization-
+        # dependent.
+        return list(dict.fromkeys(suggestions))[:5]
 
     def _calculate_confidence(
         self,

--- a/tests/services/gpu_scheduler/test_gpu_cost_service.py
+++ b/tests/services/gpu_scheduler/test_gpu_cost_service.py
@@ -369,9 +369,15 @@ class TestBudgetChecking:
             }
         }
 
-        # Setup low cost usage
+        # Setup very low cost usage so monthly forecast stays well under
+        # the 80% threshold and 90% forecast-warning trigger on every day
+        # of the month. The forecast extrapolation is
+        # (total_cost / now.day) * days_in_month, so on day 1 of a 30-day
+        # month a $20 charge projects to $600 (600% of $100 budget) and
+        # trips a forecast_warning. Using $1 caps the day-1 projection at
+        # $30 (30%), keeping the assertion stable year-round.
         cost_service._jobs_table.query.return_value = {
-            "Items": [{"cost_usd": Decimal("20"), "created_at": "2026-01-13T10:00:00Z"}]
+            "Items": [{"cost_usd": Decimal("1"), "created_at": "2026-01-13T10:00:00Z"}]
         }
 
         within_budget, alert = await cost_service.check_budget("org-123")

--- a/tests/test_orchestrator_dispatcher.py
+++ b/tests/test_orchestrator_dispatcher.py
@@ -219,7 +219,7 @@ class TestAutonomyConfiguration:
 class TestJobSpecBuilding:
     """Tests for Kubernetes Job spec building."""
 
-    def test_build_job_spec_basic(self, mock_aws_clients):
+    def test_build_job_spec_basic(self):
         """Test building a basic job spec."""
         job_spec = dispatcher._build_job_spec(
             job_id="test-job-001",
@@ -234,7 +234,7 @@ class TestJobSpecBuilding:
         assert job_spec["metadata"]["labels"]["job-id"] == "test-job-001"
         assert job_spec["metadata"]["labels"]["task-id"] == "task-001"
 
-    def test_build_job_spec_has_correct_container_resources(self, mock_aws_clients):
+    def test_build_job_spec_has_correct_container_resources(self):
         """Test job spec has correct container resources."""
         job_spec = dispatcher._build_job_spec(
             job_id="test-job-002",
@@ -249,7 +249,7 @@ class TestJobSpecBuilding:
         assert container["resources"]["limits"]["memory"] == "4Gi"
         assert container["resources"]["limits"]["cpu"] == "2"
 
-    def test_build_job_spec_encodes_payload_as_base64(self, mock_aws_clients):
+    def test_build_job_spec_encodes_payload_as_base64(self):
         """Test that payload is base64 encoded."""
         payload = {"test": "data", "nested": {"value": 123}}
         job_spec = dispatcher._build_job_spec(
@@ -269,7 +269,7 @@ class TestJobSpecBuilding:
         assert decoded["payload"] == payload
         assert decoded["task_id"] == "task-003"
 
-    def test_build_job_spec_has_ttl_and_deadline(self, mock_aws_clients):
+    def test_build_job_spec_has_ttl_and_deadline(self):
         """Test job spec has TTL and deadline settings."""
         job_spec = dispatcher._build_job_spec(
             job_id="test-job-004",
@@ -282,7 +282,7 @@ class TestJobSpecBuilding:
         assert job_spec["spec"]["backoffLimit"] == 2
         assert job_spec["spec"]["activeDeadlineSeconds"] == 1800
 
-    def test_build_job_spec_has_service_account(self, mock_aws_clients):
+    def test_build_job_spec_has_service_account(self):
         """Test job spec uses correct service account."""
         job_spec = dispatcher._build_job_spec(
             job_id="test-job-005",

--- a/tests/test_orchestrator_dispatcher.py
+++ b/tests/test_orchestrator_dispatcher.py
@@ -64,23 +64,39 @@ with (
 
 @pytest.fixture
 def mock_aws_clients():
-    """Mock all AWS clients."""
+    """Mock all AWS clients.
+
+    Patches the lazy-init getters (`get_dynamodb_client` / `get_dynamodb_resource`
+    / `get_eks_client` / `get_sqs_client`) introduced by issue #466 instead of
+    the long-gone module-level `dynamodb` / `dynamodb_client` / `eks_client` /
+    `sqs_client` attributes. Tests can set call expectations on the returned
+    MagicMocks; the dispatcher's `get_*()` calls resolve to them via the patched
+    factories.
+    """
+    mock_dynamodb = MagicMock()
+    mock_dynamodb_client = MagicMock()
+    mock_eks_client = MagicMock()
+    mock_sqs_client = MagicMock()
+    mock_sts_client = MagicMock()
+    mock_sts_client.generate_presigned_url.return_value = (
+        "https://sts.amazonaws.com/test-presigned"
+    )
+    mock_table = MagicMock()
+    mock_dynamodb.Table.return_value = mock_table
+
     with (
-        patch(f"{MODULE_PATH}.dynamodb") as mock_dynamodb,
-        patch(f"{MODULE_PATH}.dynamodb_client") as mock_dynamodb_client,
-        patch(f"{MODULE_PATH}.eks_client") as mock_eks_client,
-        patch(f"{MODULE_PATH}.sqs_client") as mock_sqs_client,
+        patch(f"{MODULE_PATH}.get_dynamodb_resource", return_value=mock_dynamodb),
+        patch(f"{MODULE_PATH}.get_dynamodb_client", return_value=mock_dynamodb_client),
+        patch(f"{MODULE_PATH}.get_eks_client", return_value=mock_eks_client),
+        patch(f"{MODULE_PATH}.get_sqs_client", return_value=mock_sqs_client),
+        patch(f"{MODULE_PATH}.get_sts_client", return_value=mock_sts_client),
     ):
-
-        # Setup mock table
-        mock_table = MagicMock()
-        mock_dynamodb.Table.return_value = mock_table
-
         yield {
             "dynamodb": mock_dynamodb,
             "dynamodb_client": mock_dynamodb_client,
             "eks_client": mock_eks_client,
             "sqs_client": mock_sqs_client,
+            "sts_client": mock_sts_client,
             "table": mock_table,
         }
 
@@ -471,9 +487,10 @@ class TestLambdaHandler:
         mock_sts.generate_presigned_url.return_value = "https://sts.amazonaws.com/test"
 
         # Patch both eks_client and boto3.client for STS
+        patched_eks = MagicMock()
         with (
-            patch.object(dispatcher, "eks_client") as patched_eks,
-            patch(f"{MODULE_PATH}.boto3.client", return_value=mock_sts),
+            patch.object(dispatcher, "get_eks_client", return_value=patched_eks),
+            patch.object(dispatcher, "get_sts_client", return_value=mock_sts),
         ):
             patched_eks.describe_cluster.return_value = {
                 "cluster": {
@@ -566,9 +583,10 @@ class TestLambdaHandler:
         mock_sts.generate_presigned_url.return_value = "https://sts.amazonaws.com/test"
 
         # Patch both eks_client and boto3.client for STS
+        patched_eks = MagicMock()
         with (
-            patch.object(dispatcher, "eks_client") as patched_eks,
-            patch(f"{MODULE_PATH}.boto3.client", return_value=mock_sts),
+            patch.object(dispatcher, "get_eks_client", return_value=patched_eks),
+            patch.object(dispatcher, "get_sts_client", return_value=mock_sts),
         ):
             patched_eks.describe_cluster.return_value = {
                 "cluster": {
@@ -695,9 +713,10 @@ class TestLambdaHandler:
         mock_sts = MagicMock()
         mock_sts.generate_presigned_url.return_value = "https://sts.amazonaws.com/test"
 
+        patched_eks = MagicMock()
         with (
-            patch.object(dispatcher, "eks_client") as patched_eks,
-            patch(f"{MODULE_PATH}.boto3.client", return_value=mock_sts),
+            patch.object(dispatcher, "get_eks_client", return_value=patched_eks),
+            patch.object(dispatcher, "get_sts_client", return_value=mock_sts),
         ):
             patched_eks.describe_cluster.return_value = {
                 "cluster": {
@@ -728,9 +747,10 @@ class TestEKSDispatch:
         mock_sts = MagicMock()
         mock_sts.generate_presigned_url.return_value = "https://sts.amazonaws.com/test"
 
+        patched_eks = MagicMock()
         with (
-            patch.object(dispatcher, "eks_client") as patched_eks,
-            patch(f"{MODULE_PATH}.boto3.client", return_value=mock_sts),
+            patch.object(dispatcher, "get_eks_client", return_value=patched_eks),
+            patch.object(dispatcher, "get_sts_client", return_value=mock_sts),
         ):
             patched_eks.describe_cluster.return_value = {
                 "cluster": {
@@ -747,7 +767,8 @@ class TestEKSDispatch:
 
     def test_dispatch_to_eks_missing_endpoint(self, mock_aws_clients):
         """Test dispatch fails when cluster endpoint is missing."""
-        with patch.object(dispatcher, "eks_client") as patched_eks:
+        patched_eks = MagicMock()
+        with patch.object(dispatcher, "get_eks_client", return_value=patched_eks):
             patched_eks.describe_cluster.return_value = {"cluster": {}}
 
             result = dispatcher._dispatch_to_eks("test-job", {})
@@ -759,7 +780,8 @@ class TestEKSDispatch:
         """Test dispatch handles EKS client error."""
         from botocore.exceptions import ClientError
 
-        with patch.object(dispatcher, "eks_client") as patched_eks:
+        patched_eks = MagicMock()
+        with patch.object(dispatcher, "get_eks_client", return_value=patched_eks):
             patched_eks.describe_cluster.side_effect = ClientError(
                 {
                     "Error": {
@@ -786,13 +808,9 @@ class TestEKSToken:
 
     def test_get_eks_token_format(self, mock_aws_clients):
         """Test EKS token has correct format."""
-        with patch(f"{MODULE_PATH}.boto3.client") as mock_boto:
-            mock_sts = MagicMock()
-            mock_sts.generate_presigned_url.return_value = (
-                "https://sts.amazonaws.com/..."
-            )
-            mock_boto.return_value = mock_sts
-
+        mock_sts = MagicMock()
+        mock_sts.generate_presigned_url.return_value = "https://sts.amazonaws.com/..."
+        with patch.object(dispatcher, "get_sts_client", return_value=mock_sts):
             token = dispatcher._get_eks_token("test-cluster")
 
             assert token.startswith("k8s-aws-v1.")
@@ -822,9 +840,10 @@ class TestEdgeCases:
         mock_sts = MagicMock()
         mock_sts.generate_presigned_url.return_value = "https://sts.amazonaws.com/test"
 
+        patched_eks = MagicMock()
         with (
-            patch.object(dispatcher, "eks_client") as patched_eks,
-            patch(f"{MODULE_PATH}.boto3.client", return_value=mock_sts),
+            patch.object(dispatcher, "get_eks_client", return_value=patched_eks),
+            patch.object(dispatcher, "get_sts_client", return_value=mock_sts),
         ):
             patched_eks.describe_cluster.return_value = {
                 "cluster": {
@@ -862,9 +881,10 @@ class TestEdgeCases:
         mock_sts = MagicMock()
         mock_sts.generate_presigned_url.return_value = "https://sts.amazonaws.com/test"
 
+        patched_eks = MagicMock()
         with (
-            patch.object(dispatcher, "eks_client") as patched_eks,
-            patch(f"{MODULE_PATH}.boto3.client", return_value=mock_sts),
+            patch.object(dispatcher, "get_eks_client", return_value=patched_eks),
+            patch.object(dispatcher, "get_sts_client", return_value=mock_sts),
         ):
             patched_eks.describe_cluster.return_value = {
                 "cluster": {

--- a/tests/test_orchestrator_settings_endpoints.py
+++ b/tests/test_orchestrator_settings_endpoints.py
@@ -318,9 +318,10 @@ class TestSettingsUpdate:
 
         mock_service = MagicMock()
         mock_service.get_setting = AsyncMock(return_value=default_settings)
-        mock_service.save_setting = AsyncMock(return_value=True)
+        mock_service.update_setting = AsyncMock(return_value=True)
 
         mock_publisher = MagicMock()
+        mock_publisher.publish_metric = AsyncMock()
         mock_background = MagicMock()
 
         request = UpdateOrchestratorSettingsRequest(warm_pool_replicas=3)
@@ -339,7 +340,7 @@ class TestSettingsUpdate:
             )
 
         assert result is not None
-        mock_service.save_setting.assert_called_once()
+        mock_service.update_setting.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_update_settings_no_updates(self, mock_admin_user, mock_rate_limit):
@@ -347,6 +348,7 @@ class TestSettingsUpdate:
         from src.api.orchestrator_settings_endpoints import update_orchestrator_settings
 
         mock_publisher = MagicMock()
+        mock_publisher.publish_metric = AsyncMock()
         mock_background = MagicMock()
 
         request = UpdateOrchestratorSettingsRequest()
@@ -375,6 +377,7 @@ class TestSettingsUpdate:
         mock_service.get_setting = AsyncMock(return_value=default_settings)
 
         mock_publisher = MagicMock()
+        mock_publisher.publish_metric = AsyncMock()
         mock_background = MagicMock()
 
         # Try to enable hybrid while explicitly disabling warm pool
@@ -415,6 +418,7 @@ class TestSettingsUpdate:
         mock_service.update_organization_setting = AsyncMock(return_value=True)
 
         mock_publisher = MagicMock()
+        mock_publisher.publish_metric = AsyncMock()
         mock_background = MagicMock()
 
         request = UpdateOrchestratorSettingsRequest(warm_pool_replicas=5)
@@ -452,9 +456,10 @@ class TestModeSwitching:
 
         mock_service = MagicMock()
         mock_service.get_setting = AsyncMock(return_value=default_settings)
-        mock_service.save_setting = AsyncMock(return_value=True)
+        mock_service.update_setting = AsyncMock(return_value=True)
 
         mock_publisher = MagicMock()
+        mock_publisher.publish_metric = AsyncMock()
         mock_background = MagicMock()
 
         request = SwitchModeRequest(target_mode=DeploymentMode.WARM_POOL)
@@ -473,7 +478,7 @@ class TestModeSwitching:
             )
 
         assert result is not None
-        mock_service.save_setting.assert_called_once()
+        mock_service.update_setting.assert_called_once()
         mock_background.add_task.assert_called_once()
 
     @pytest.mark.asyncio
@@ -487,6 +492,7 @@ class TestModeSwitching:
         mock_service.get_setting = AsyncMock(return_value=warm_pool_settings)
 
         mock_publisher = MagicMock()
+        mock_publisher.publish_metric = AsyncMock()
         mock_background = MagicMock()
 
         request = SwitchModeRequest(target_mode=DeploymentMode.WARM_POOL)
@@ -505,7 +511,7 @@ class TestModeSwitching:
             )
 
         # Should return without saving when already in target mode
-        mock_service.save_setting.assert_not_called()
+        mock_service.update_setting.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_switch_mode_cooldown_active(self, mock_admin_user, mock_rate_limit):
@@ -525,6 +531,7 @@ class TestModeSwitching:
         mock_service.get_setting = AsyncMock(return_value=settings)
 
         mock_publisher = MagicMock()
+        mock_publisher.publish_metric = AsyncMock()
         mock_background = MagicMock()
 
         request = SwitchModeRequest(target_mode=DeploymentMode.WARM_POOL)
@@ -564,9 +571,10 @@ class TestModeSwitching:
 
         mock_service = MagicMock()
         mock_service.get_setting = AsyncMock(return_value=settings)
-        mock_service.save_setting = AsyncMock(return_value=True)
+        mock_service.update_setting = AsyncMock(return_value=True)
 
         mock_publisher = MagicMock()
+        mock_publisher.publish_metric = AsyncMock()
         mock_background = MagicMock()
 
         request = SwitchModeRequest(
@@ -589,7 +597,7 @@ class TestModeSwitching:
             )
 
         assert result is not None
-        mock_service.save_setting.assert_called_once()
+        mock_service.update_setting.assert_called_once()
 
 
 # =============================================================================

--- a/tests/test_realtime_event_publisher.py
+++ b/tests/test_realtime_event_publisher.py
@@ -39,11 +39,23 @@ class MockClientError(Exception):
 
 mock_botocore.exceptions.ClientError = MockClientError
 
+# If another test already imported realtime_event_publisher before this
+# file's setup ran, its `from botocore.exceptions import ClientError` is
+# bound to the real ClientError, not MockClientError -- so `except
+# ClientError` in production won't catch the MockClientError instances
+# raised by tests below. Re-bind the production module's name explicitly
+# so the test exception class is what the production module sees,
+# regardless of import order. (Linux CI doesn't fork-isolate this file,
+# unlike macOS where `pytestmark = pytest.mark.forked` sidesteps the
+# issue per-test.)
+import src.services.realtime_event_publisher as _rep_module
 from src.services.realtime_event_publisher import (
     ConnectionInfo,
     LocalEventPublisher,
     RealtimeEventPublisher,
 )
+
+_rep_module.ClientError = MockClientError
 
 # Restore original modules to prevent pollution of other tests
 for mod_name, original in _original_modules.items():

--- a/tests/test_recurring_task_endpoints.py
+++ b/tests/test_recurring_task_endpoints.py
@@ -223,7 +223,10 @@ class TestCreateRecurringTask:
         )
 
         assert response.status_code == 400
-        assert "Invalid cron expression" in response.json()["detail"]
+        # The create endpoint deliberately sanitises ValueError messages to a
+        # generic detail to avoid leaking internal validation strings; the raw
+        # message is logged server-side. See recurring_task_endpoints.py:218.
+        assert "Invalid task configuration" in response.json()["detail"]
 
     def test_create_task_missing_name(self, client, mock_service):
         """Test creation without required name field."""

--- a/tests/test_recurring_task_service.py
+++ b/tests/test_recurring_task_service.py
@@ -894,8 +894,21 @@ class TestServiceErrorPaths:
     """Tests for service error handling paths."""
 
     @pytest.fixture
-    def service_no_table(self):
-        """Create a service with no DynamoDB table."""
+    def service_no_table(self, monkeypatch):
+        """Create a service with no DynamoDB table.
+
+        Patches ``boto3.resource`` to raise so the production ``table``
+        property's lazy init falls through to ``self._table = None``
+        (see recurring_task_service.py:372-381). Without this, the
+        lazy init creates a real boto3 Table on Linux CI and the
+        subsequent ``put_item`` fails with
+        ``UnrecognizedClientException`` because CI has no credentials.
+        """
+        import boto3
+
+        monkeypatch.setattr(
+            boto3, "resource", MagicMock(side_effect=Exception("no creds in test"))
+        )
         service = RecurringTaskService(table_name="test-table")
         service._table = None
         return service

--- a/tests/test_team_invitation_service.py
+++ b/tests/test_team_invitation_service.py
@@ -38,6 +38,30 @@ from src.services.team_invitation_service import (
 # =============================================================================
 
 
+@pytest.fixture(autouse=True)
+def _stub_boto3_resource(monkeypatch):
+    """Stub boto3.resource so the service's lazy ``table`` property never
+    tries a real DynamoDB call on Linux CI (where credentials are absent
+    and a ``put_item`` raises ``UnrecognizedClientException``).
+
+    The stub returns a permissive MagicMock chain, so
+    ``boto3.resource("dynamodb").Table(...)`` yields a MagicMock that
+    silently absorbs ``put_item`` / ``update_item`` / ``delete_item``
+    and returns ``{"Items": []}`` from ``query``. Tests that need
+    specific table behaviour still override ``service._table`` with
+    their own ``mock_dynamodb_table`` fixture, which takes precedence
+    over the lazy property's stub.
+    """
+    import boto3
+
+    fake_table = MagicMock()
+    fake_table.query.return_value = {"Items": []}
+    fake_table.get_item.return_value = {}
+    fake_resource = MagicMock()
+    fake_resource.Table.return_value = fake_table
+    monkeypatch.setattr(boto3, "resource", lambda *a, **kw: fake_resource)
+
+
 @pytest.fixture
 def service():
     """Create a team invitation service for testing."""
@@ -654,7 +678,15 @@ class TestRevokeInvitation:
     @pytest.mark.asyncio
     async def test_revoke_invitation_no_table(self, service):
         """Test revoke when table not available."""
-        result = await service.revoke_invitation("inv_123", "user_001")
+        # The autouse boto3 stub would otherwise leave ``self.table`` truthy
+        # via the lazy property; null it out explicitly to exercise the
+        # "no table" code path on line 412 of team_invitation_service.
+        service._table = None
+        service._dynamodb = None
+        import boto3
+
+        with patch.object(boto3, "resource", side_effect=Exception("no creds")):
+            result = await service.revoke_invitation("inv_123", "user_001")
         assert result is False
 
     @pytest.mark.asyncio

--- a/tests/test_team_invitation_service.py
+++ b/tests/test_team_invitation_service.py
@@ -765,7 +765,7 @@ class TestShareableLink:
         """Test shareable link with default base URL."""
         link = await service.generate_shareable_link("org_001")
 
-        assert "https://app.aenealabs.com/join/org_001/" in link
+        assert "https://app.aura.local/join/org_001/" in link
         # Should contain a token
         assert len(link.split("/")[-1]) > 10
 
@@ -1415,6 +1415,6 @@ class TestShareableLinkEdgeCases:
         """Test shareable link format."""
         link = await service.generate_shareable_link("org_test")
 
-        assert link.startswith("https://app.aenealabs.com/join/org_test/")
+        assert link.startswith("https://app.aura.local/join/org_test/")
         parts = link.split("/")
         assert len(parts[-1]) > 10  # Token has sufficient length

--- a/tests/test_ticketing_endpoints.py
+++ b/tests/test_ticketing_endpoints.py
@@ -799,7 +799,12 @@ class TestEdgeCases:
             )
 
         assert result["success"] is False
-        assert "Connection failed" in result["error_message"]
+        # Production sanitises the raw exception message to a generic
+        # "Connection test failed due to an internal error." string
+        # (ticketing_endpoints.py:292) to avoid leaking internal error
+        # detail to callers. The raw "Connection failed" sentinel
+        # remains in server-side logs.
+        assert "Connection test failed" in result["error_message"]
 
     @pytest.mark.asyncio
     async def test_invalid_priority_fallback(self, mock_rate_limit, sample_ticket):

--- a/tests/test_ws_message_handler.py
+++ b/tests/test_ws_message_handler.py
@@ -96,6 +96,19 @@ get_conversation_history = ws_message.get_conversation_history
 save_message = ws_message.save_message
 send_to_connection = ws_message.send_to_connection
 
+# Re-bind ws_message's references to the test mocks AFTER import. On Linux
+# CI the file isn't fork-isolated, so if any earlier test imported
+# ws_message (or boto3 / botocore.exceptions / the lazy aws_clients
+# getters), the production module's symbols are bound to the real
+# objects and the sys.modules mutation above is a no-op. Explicit
+# attribute rebinding makes the patches stick regardless of import
+# order. See the wave-2 fix in test_realtime_event_publisher.py for
+# the same pattern.
+ws_message.boto3 = mock_boto3
+ws_message.ClientError = MockClientError
+ws_message.get_dynamodb_resource = lambda *a, **kw: mock_dynamodb_resource
+ws_message.get_bedrock_runtime_client = lambda *a, **kw: mock_bedrock_client
+
 # Restore original modules to prevent pollution of other tests
 for mod_name, original in _original_modules.items():
     if original is not None:

--- a/tests/test_ws_message_handler.py
+++ b/tests/test_ws_message_handler.py
@@ -104,10 +104,23 @@ send_to_connection = ws_message.send_to_connection
 # attribute rebinding makes the patches stick regardless of import
 # order. See the wave-2 fix in test_realtime_event_publisher.py for
 # the same pattern.
+#
+# Crucially, we also rebind the per-table accessors (`get_connections_table`
+# etc.) directly to the specific mock-tables rather than going through
+# `get_dynamodb_resource().Table(<name>)`. The `<name>` constants
+# (`CONNECTIONS_TABLE`, ...) are evaluated at module-import time from
+# env vars; if an earlier test mutated `ENVIRONMENT` / `PROJECT_NAME`,
+# those constants drift and `mock_dynamodb_resource.Table.side_effect`
+# falls through to its `MagicMock()` fallback, producing an unmocked
+# table chain that breaks every test below. Binding the accessors
+# sidesteps the env-coupling entirely.
 ws_message.boto3 = mock_boto3
 ws_message.ClientError = MockClientError
 ws_message.get_dynamodb_resource = lambda *a, **kw: mock_dynamodb_resource
 ws_message.get_bedrock_runtime_client = lambda *a, **kw: mock_bedrock_client
+ws_message.get_connections_table = lambda: mock_connections_table
+ws_message.get_conversations_table = lambda: mock_conversations_table
+ws_message.get_messages_table = lambda: mock_messages_table
 
 # Restore original modules to prevent pollution of other tests
 for mod_name, original in _original_modules.items():


### PR DESCRIPTION
## Summary

Reopens the cleanup work that was on PR #248 (closed during the prior PR sweep, branch retained). Lands the 6 wave commits on `fix/main-test-bugs` that fix pre-existing test failures on `main` blocking Dependabot CI across every dependency-bump branch.

**Scope:** pytest test rot only. Pre-existing mypy debt (765 errors in 221 files surfaced in the same `Python Quality & Tests` job) is out of scope for this PR and remains a separate workstream.

## What this PR fixes

Eight categories of pre-existing main-branch issues, all surfaced as failures on Dependabot PRs but unrelated to any dependency bump:

1. **Date-of-month math bug** — `src/services/scheduling/models.py:84` had `now.replace(day=now.day + 30)` which raises `ValueError` whenever `now.day == 1` in any month with fewer than 31 days. Dead code (line 88 overwrites it immediately).
2. **GPU forecast test stale dates** — `test_gpu_cost_service.py::test_check_budget_within_limit` used a $20 mock cost projected via `(cost / now.day) * 30`, tripping the 90% forecast-warning alert on days 1-5 of any 30-day month.
3. **Dispatcher tests post-#466 refactor** — `test_orchestrator_dispatcher.py` fixture patched module-level attrs (`dynamodb`, `eks_client`, etc.) that were replaced by `get_*()` lazy getters under #466.
4. **Async-await mismatches** — `test_orchestrator_settings_endpoints.py` used `MagicMock` where the endpoint awaits `publisher.publish_metric`, and mocked a `save_setting` method renamed to `update_setting`.
5. **sys.modules mutation pollution** — `test_realtime_event_publisher.py` and `test_ws_message_handler.py` replaced `botocore.exceptions` in `sys.modules` before importing the production module, but on Linux CI without fork-isolation, if any earlier test had already imported the production module, `except ClientError:` doesn't catch the test's `MockClientError`. Rebind production module attrs after import.
6. **Real boto3 leaking through** — `test_team_invitation_service.py`, `test_recurring_task_service.py`, `test_ws_message_handler.py` had fixtures that didn't fully mock boto3; lazy-table accessors made real DynamoDB/Bedrock/EKS calls that fail on CI runners. Added autouse `_stub_boto3_resource` fixture and direct rebinds for env-derived table-name accessors.
7. **Error-message sanitization drift** — `test_ticketing_endpoints.py` and `test_recurring_task_endpoints.py` asserted raw exception messages where production now sanitises to generic strings (security pattern: don't leak internals to clients).
8. **PYTHONHASHSEED non-determinism** — `ssr/failure_analyzer.py:_suggest_context` used `list(set(suggestions))[:5]` for dedup-and-truncate; `set` ordering is non-deterministic, so the entry the test looked for randomly got dropped depending on the hash seed.

## Diff size

11 files changed, 190 insertions(+), 73 deletions(-).

- `src/services/scheduling/models.py`
- `src/services/ssr/failure_analyzer.py`
- `tests/gpu_scheduler/test_gpu_cost_service.py`
- `tests/test_orchestrator_dispatcher.py`
- `tests/test_orchestrator_settings_endpoints.py`
- `tests/test_realtime_event_publisher.py`
- `tests/test_recurring_task_endpoints.py`
- `tests/test_recurring_task_service.py`
- `tests/test_team_invitation_service.py`
- `tests/test_ticketing_endpoints.py`
- `tests/test_ws_message_handler.py`

## CI expectations

- `Python Quality & Tests` will still be red on this PR because of the unrelated 765 mypy errors on `main`. Once merged, the **next** Dependabot CI cycle will surface a smaller set of failures (the residual rot beyond these 8 categories, plus mypy).
- Each commit body documents local reproduction (`pytest <file> -p no:forked` matching Linux CI's no-fork-isolation execution model).

## Test plan

- [ ] Confirm pytest passes locally for each touched file
- [ ] Squash-merge once review approves; admin-override the mypy gate per the same policy applied to the frontend dep PRs (#251, #252, #263, #265, #266, #267)
- [ ] After merge, watch the next Dependabot CI cycle to confirm these 8 categories are gone
