### PR TITLE
fix(security): obfuscate mock Slack webhook URL to silence Trivy false positive

### DIFF
--- a/frontend/src/services/integrationApi.js
+++ b/frontend/src/services/integrationApi.js
@@ -583,7 +583,7 @@ let mockConnectedIntegrations = [
     organization_id: 'org-acme-corp-7x2',
     organization_name: 'Acme Corporation',
     config: {
-      webhook_url: 'https://hooks.slack.com/services/T02XXXXXX/B04YYYYYY/zzzzzzzzzzzzzzzzzzzzzzzz',
+      webhook_url: 'https://hooks.slack.example/services/T02XXXXXX/B04YYYYYY/zzzzzzzzzzzzzzzzzzzzzzzz',
       default_channel: '#security-alerts',
       bot_token: '***configured***',
       channels: {


### PR DESCRIPTION
## Summary

- One-line mock URL change in `frontend/src/services/integrationApi.js:586`: swap `hooks.slack.com` → `hooks.slack.example` (RFC 2606 reserved TLD) so Trivy's `slack-web-hook` rule no longer matches.
- Resolves stale code-scanning alert #239. The matched line is mock data with obvious placeholder tokens (`T02XXXXXX/B04YYYYYY/zzz...`) — not a real secret.

## Companion dismissals

- #278 (js-cookie HIGH) — already fixed via #263's `amazon-cognito-identity-js@6.3.18` upgrade (declares `js-cookie@^3.0.7`; lockfile resolved to 3.0.8). Will be dismissed as `won't fix` with explanation.
- #238 (SlackConfig.jsx UI placeholder) — kept as-is for UX; per `frontend/CLAUDE.md` ("Form field names like 'Password' are UI labels, not secrets"). Will be dismissed as `false positive`.

## Test plan

- [ ] CI green (frontend-only change, will hit the usual `Python Quality & Tests` policy gap and require admin-override)
- [ ] After merge, Trivy re-scan no longer produces alert #239