### PR TITLE
ci: --no-cache-dir on native-dep installs (issue #221 phase 1)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,7 +64,10 @@ jobs:
           # (time.perf_counter, statistics, resource) -- no
           # pytest-benchmark or other external bench libraries.
           pip install --upgrade pip
-          pip install -r requirements.txt
+          # --no-cache-dir on the native-dep install so a stale cached
+          # numpy-ABI wheel can't crash the benchmark run after a numpy
+          # bump (see issue #221).
+          pip install --no-cache-dir -r requirements.txt
 
       - name: Run ingestion benchmarks
         run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -81,13 +81,21 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install black==26.3.1 flake8 mypy bandit[toml]
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          # Native deps (torch + everything via requirements.txt -- numpy,
+          # sklearn, hdbscan) install with --no-cache-dir to force a fresh
+          # wheel fetch every run. The pip cache otherwise hangs onto wheels
+          # compiled against a stale numpy ABI (issue #221 / PR #172): when
+          # numpy is bumped across the 1.x->2.x ABI boundary, cached native
+          # wheels built against numpy 1.x crash with SIGSEGV when handed
+          # numpy 2.x arrays by other native deps. Bypassing the cache here
+          # is the prerequisite for unpinning numpy.
+          pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
           # requirements.txt install must fail loudly. Previously this line
           # ended in `|| true`, which silently masked transient PyPI errors
           # and unavailable wheels and left required packages uninstalled --
           # subsequent pytest steps then failed with ModuleNotFoundError,
           # creating opaque "green-by-flake" CI behaviour. See issue #190.
-          pip install -r requirements.txt
+          pip install --no-cache-dir -r requirements.txt
           pip install pytest pytest-cov pytest-asyncio pytest-forked pytest-xdist
           pip install 'pydantic[email]'  # Required for email validation in tests
 

--- a/.github/workflows/dependency-risk-audit.yml
+++ b/.github/workflows/dependency-risk-audit.yml
@@ -83,7 +83,9 @@ jobs:
           # so we install the tracked Watch / At-Risk packages. This
           # is intentionally narrow -- the audit doesn't need the full
           # project install, only the deps it tracks for staleness.
-          pip install -r requirements.txt || true
+          # --no-cache-dir avoids a stale-ABI scenario after a numpy
+          # bump (see issue #221).
+          pip install --no-cache-dir -r requirements.txt || true
 
       - name: Install frontend deps for npm audit
         working-directory: frontend

--- a/.github/workflows/nightly-live-llm.yml
+++ b/.github/workflows/nightly-live-llm.yml
@@ -71,7 +71,9 @@ jobs:
           # the live-LLM smoke uses only stdlib + the project's own
           # BedrockLLMService -- no extra test deps.
           pip install --upgrade pip
-          pip install -r requirements.txt
+          # --no-cache-dir avoids stale numpy-ABI wheels after a numpy
+          # bump (see issue #221).
+          pip install --no-cache-dir -r requirements.txt
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1


### PR DESCRIPTION
## Summary

Prerequisite for the numpy 2.x unpin tracked in #221. Adds `--no-cache-dir` to the four CI workflows' pip-install steps that touch native deps (`torch` + everything pulled by `requirements.txt` — `numpy`, `sklearn`, `hdbscan`). Pure-Python installs (`black`, `flake8`, `mypy`, `pytest`, …) keep using the cache.

## Root cause this guards against

GitHub Actions' `cache: 'pip'` on `actions/setup-python` preserves downloaded wheels across runs. When numpy is later bumped across the 1.x → 2.x ABI boundary (as in PR #172), the cache still serves wheels for `sklearn` / `hdbscan` / `torch` that were compiled against numpy 1.x headers; those crash with SIGSEGV when other native deps hand them numpy 2.x arrays. That's what tripped `tests/services/memory_evolution/test_abstract_operation.py::TestMemoryClusteringService::test_cluster_memories_fallback` at the 14% mark in May 2026.

Forcing fresh wheels per run on native-dep installs side-steps this without disabling the cache for the small, ABI-safe installs.

## Why "phase 1"

Issue #221's Phase 1 calls out exactly this need: *"Add `pip install --upgrade --no-cache-dir` step to CI to force fresh wheels (avoid stale-wheel ABI mismatch)."* This PR is that step.

PR-2 (the actual numpy unpin in `requirements.txt` + `deploy/docker/memory-service/requirements.txt`) will land after this is verified green.

## Scoping note (re #221)

Investigation while preparing this PR also surfaced that **the 765 mypy errors on current main are NOT numpy-induced** — they reference no numpy types and are present with `numpy<2.0` pinned. Issue #221's Phase 3 conflates two independent workstreams (numpy migration vs. pre-existing mypy debt). Worth splitting the mypy sweep into its own initiative; flagged separately, not part of this PR.

## Files changed

| Workflow | Change |
|---|---|
| `code-quality.yml` | `--no-cache-dir` on torch + requirements.txt |
| `benchmarks.yml` | `--no-cache-dir` on requirements.txt |
| `dependency-risk-audit.yml` | `--no-cache-dir` on requirements.txt (keeps `|| true`) |
| `nightly-live-llm.yml` | `--no-cache-dir` on requirements.txt |

## Test plan

- [ ] CI green on this branch (workflow-config only change; behavior is "fresher wheels," not different code)
- [ ] After merge, observe one full code-quality run on `main` completes successfully
- [ ] Land PR-2 (numpy unpin) and confirm SIGSEGV does not recur