### PR TITLE
chore(deps): bump codeql-action init/autobuild/analyze atomically

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,16 +37,16 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
         with:
           languages: ${{ matrix.language }}
           config-file: .github/codeql/codeql-config.yml
           queries: +security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Bundles Dependabot PRs #275, #276, #278 into a single atomic change.

Each of those bumps only **one** of the three `codeql-action` steps in `.github/workflows/codeql.yml`, which leaves the workflow with a mix of old + new versions and triggers:

\`\`\`
##[error]Loaded a configuration file for version '4.35.4', but running version '4.36.2'
\`\`\`

`init` / `autobuild` / `analyze` must all advance together.

Target SHA `8aad20d150bbac5944a9f9d289da16a4b0d87c1e` matches the one already merged via #274 for `upload-sarif`, so post-merge all four codeql-action steps share the same revision.

Closes #275, #276, #278.