### PR TITLE
fix(mypy): clear 13 type errors in identity/providers/saml_provider.py

### DIFF
--- a/src/services/identity/providers/saml_provider.py
+++ b/src/services/identity/providers/saml_provider.py
@@ -149,10 +149,7 @@ class SAMLProvider(IdentityProvider):
 
         conn = config.connection_settings
         self.sp_entity_id = conn.get("sp_entity_id", "https://api.aenealabs.com/saml")
-        self.idp_entity_id = conn.get("idp_entity_id")
-        self.idp_sso_url = conn.get("idp_sso_url")
         self.idp_slo_url = conn.get("idp_slo_url")
-        self.idp_certificate = conn.get("idp_certificate")  # Base64 PEM
         self.acs_url = conn.get("acs_url", "https://api.aenealabs.com/auth/saml/acs")
         self.name_id_format = conn.get(
             "name_id_format",
@@ -163,13 +160,22 @@ class SAMLProvider(IdentityProvider):
         self.want_assertions_encrypted = conn.get("want_assertions_encrypted", False)
         self.allowed_clock_skew = conn.get("allowed_clock_skew", 300)
 
-        # Validate required settings
-        if not self.idp_entity_id:
+        # Validate required settings and bind with explicit `str` annotation
+        # so downstream code (and mypy) sees them as non-Optional.
+        idp_entity_id = conn.get("idp_entity_id")
+        if not idp_entity_id:
             raise ConfigurationError("SAML idp_entity_id is required")
-        if not self.idp_sso_url:
+        self.idp_entity_id: str = idp_entity_id
+
+        idp_sso_url = conn.get("idp_sso_url")
+        if not idp_sso_url:
             raise ConfigurationError("SAML idp_sso_url is required")
-        if not self.idp_certificate:
+        self.idp_sso_url: str = idp_sso_url
+
+        idp_certificate = conn.get("idp_certificate")  # Base64 PEM
+        if not idp_certificate:
             raise ConfigurationError("SAML idp_certificate is required")
+        self.idp_certificate: str = idp_certificate
 
         # SP credentials loaded from Secrets Manager
         self._sp_private_key: str | None = None
@@ -280,14 +286,28 @@ class SAMLProvider(IdentityProvider):
         # Build signing input
         query_string = urlencode(params)
 
+        if self._sp_private_key is None:
+            logger.warning("SP private key not loaded; skipping request signing")
+            return params
+
         # Sign with SP private key
         try:
             from cryptography.hazmat.primitives import hashes, serialization
-            from cryptography.hazmat.primitives.asymmetric import padding
+            from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
             private_key = serialization.load_pem_private_key(
                 self._sp_private_key.encode(), password=None
             )
+            if not isinstance(private_key, rsa.RSAPrivateKey):
+                # The SigAlg above is RSA-SHA256; reject non-RSA keys
+                # explicitly rather than silently producing an invalid
+                # signature.
+                logger.error(
+                    "SP private key is not an RSA key (got %s); skipping "
+                    "request signing",
+                    type(private_key).__name__,
+                )
+                return params
             signature = private_key.sign(
                 query_string.encode(),
                 padding.PKCS1v15(),
@@ -544,6 +564,7 @@ class SAMLProvider(IdentityProvider):
 
             values = attr.findall(f"{{{SAML_NS}}}AttributeValue")
             if values:
+                attr_value: str | list[str]
                 if len(values) == 1:
                     attr_value = values[0].text or ""
                 else:


### PR DESCRIPTION
Demonstration of chipping away at the 765-error mypy debt that's been outstanding since the numpy 2.x migration thread (#221 / #291) split it out as its own initiative. One file end-to-end.

## Result

Local mypy 2.1.0 run:

| | errors | files with errors |
|---|---|---|
| before | 935 | 216 |
| after | 922 | 215 |
| delta | **-13** | **-1** |

CI's reported count is 765 (lower, because CI installs the latest mypy from PyPI rather than the 2.1.0 pinned in `pyproject.toml`). Direction is the same — post-merge CI should report 752.

## Why `saml_provider.py`

Top-tier file for impact (21 errors per the per-file breakdown), security-critical code where type confusion can mask real bugs, and **not** excluded from coverage (so unlike `*/providers/self_hosted/*` and `*/migration/*`, fixing it actually contributes to quality gates).

## Six underlying fixes (13 errors)

1. **Constructor binds validated `conn.get(...)` values to explicit `str` typed attributes** for `idp_entity_id`, `idp_sso_url`, `idp_certificate`. Previously each was inferred as `Any | None`, so downstream methods needed null guards mypy couldn't see were redundant (the validation block at the top of `__init__` already raises on missing values). Fixes errors at lines 189 (`b64decode`) and 638 (`session.head`).

2. **`_sign_redirect_params` gets an early-return guard for `self._sp_private_key is None`.** The method was already called only inside `if ... and self._sp_private_key` (line 256), but the guard wasn't visible at the method's entry, so `.encode()` looked like a None-dereference. Fixes error at line 289.

3. **The same method asserts `isinstance(private_key, rsa.RSAPrivateKey)` before `.sign(data, padding, hashes)`.** The `SigAlg` it sets is `rsa-sha256`, so non-RSA keys would silently produce invalid signatures or raise opaque `AttributeError`s. Now they short-circuit with a clear log line. Fixes 9 errors at lines 291 and 293 (the various union-arm errors from `load_pem_private_key`'s wide return type).

4. **`_extract_attributes` explicitly annotates `attr_value: str | list[str]`** so the branch that reassigns single-value to list doesn't widen the variable's inferred type. Fixes error at line 550.

## Test plan

- [ ] CI green (no test changes, just type refinements; behavioural impact limited to the `_sign_redirect_params` short-circuits, which are tighter than the previous attribute-error-or-runtime-crash behaviour)
- [ ] After merge, next CI run on `main` reports ~752 mypy errors (down from 765)