### PR TITLE
fix(mypy): clear 16 type errors in vulnerability_scanner/parsing/dataflow.py

### DIFF
--- a/src/services/vulnerability_scanner/parsing/dataflow.py
+++ b/src/services/vulnerability_scanner/parsing/dataflow.py
@@ -898,9 +898,9 @@ class PythonTaintAnalyzer:
 
         paired: list[tuple[CodeUnit, tree_sitter.Node]] = []
         for unit in py_units:
-            node = node_by_line.get(unit.location.start_line)
-            if node is not None:
-                paired.append((unit, node))
+            matched_node = node_by_line.get(unit.location.start_line)
+            if matched_node is not None:
+                paired.append((unit, matched_node))
         return paired
 
     # ------------------------------------------------------------------
@@ -2547,9 +2547,9 @@ class CTaintAnalyzer:
 
         paired: list[tuple[CodeUnit, tree_sitter.Node]] = []
         for unit in c_units:
-            node = node_by_line.get(unit.location.start_line)
-            if node is not None:
-                paired.append((unit, node))
+            matched_node = node_by_line.get(unit.location.start_line)
+            if matched_node is not None:
+                paired.append((unit, matched_node))
         return paired
 
     # ------------------------------------------------------------------
@@ -4230,10 +4230,10 @@ class CppTaintAnalyzer:
         used_node_ids: set[int] = set()
         unpaired_units: list[CodeUnit] = []
         for unit in cpp_units:
-            node = node_by_line.get(unit.location.start_line)
-            if node is not None:
-                paired.append((unit, node))
-                used_node_ids.add(id(node))
+            matched_node = node_by_line.get(unit.location.start_line)
+            if matched_node is not None:
+                paired.append((unit, matched_node))
+                used_node_ids.add(id(matched_node))
             else:
                 unpaired_units.append(unit)
 
@@ -5544,8 +5544,6 @@ def _cpp_stream_sink_for_binary(node: tree_sitter.Node, source: bytes) -> Option
         if left is None:
             return None
         cursor = left
-    if cursor is None:
-        return None
     if cursor.type == "qualified_identifier":
         text = _expression_text(cursor, source)
         if text in _CPP_STREAM_SINK_NAMES:
@@ -6282,9 +6280,9 @@ class JavaScriptTaintAnalyzer:
 
         paired: list[tuple[CodeUnit, tree_sitter.Node]] = []
         for unit in js_units:
-            node = node_by_line.get(unit.location.start_line)
-            if node is not None:
-                paired.append((unit, node))
+            matched_node = node_by_line.get(unit.location.start_line)
+            if matched_node is not None:
+                paired.append((unit, matched_node))
         return paired
 
     # ------------------------------------------------------------------
@@ -7531,9 +7529,9 @@ class TypeScriptTaintAnalyzer(JavaScriptTaintAnalyzer):
 
         paired: list[tuple[CodeUnit, tree_sitter.Node]] = []
         for unit in ts_units:
-            node = node_by_line.get(unit.location.start_line)
-            if node is not None:
-                paired.append((unit, node))
+            matched_node = node_by_line.get(unit.location.start_line)
+            if matched_node is not None:
+                paired.append((unit, matched_node))
         return paired
 
     # ------------------------------------------------------------------
@@ -8047,9 +8045,9 @@ class JavaTaintAnalyzer:
 
         paired: list[tuple[CodeUnit, tree_sitter.Node]] = []
         for unit in java_units:
-            node = node_by_line.get(unit.location.start_line)
-            if node is not None:
-                paired.append((unit, node))
+            matched_node = node_by_line.get(unit.location.start_line)
+            if matched_node is not None:
+                paired.append((unit, matched_node))
         return paired
 
     # ------------------------------------------------------------------
@@ -8812,10 +8810,10 @@ class JavaTaintAnalyzer:
         if t in ("string_literal", "character_literal"):
             return _java_aggregate_taint_over_children(expr, source, taint_map)
         if t == "cast_expression":
-            inner = expr.child_by_field_name("value")
-            if inner is not None:
+            cast_inner = expr.child_by_field_name("value")
+            if cast_inner is not None:
                 return self._expression_taint(
-                    expr=inner,
+                    expr=cast_inner,
                     source=source,
                     file_path=file_path,
                     scan_id=scan_id,
@@ -9803,9 +9801,9 @@ class RustTaintAnalyzer:
 
         paired: list[tuple[CodeUnit, tree_sitter.Node]] = []
         for unit in rs_units:
-            node = node_by_line.get(unit.location.start_line)
-            if node is not None:
-                paired.append((unit, node))
+            matched_node = node_by_line.get(unit.location.start_line)
+            if matched_node is not None:
+                paired.append((unit, matched_node))
         return paired
 
     # ------------------------------------------------------------------
@@ -11693,9 +11691,9 @@ class GoTaintAnalyzer:
             stack.extend(node.children)
         paired: list[tuple[CodeUnit, tree_sitter.Node]] = []
         for unit in go_units:
-            node = node_by_line.get(unit.location.start_line)
-            if node is not None:
-                paired.append((unit, node))
+            matched_node = node_by_line.get(unit.location.start_line)
+            if matched_node is not None:
+                paired.append((unit, matched_node))
         return paired
 
     def _summarize_function(


### PR DESCRIPTION
Third file in the mypy debt sweep, after #295 (saml_provider.py) and #296 (airgap/edge_runtime.py). Security-critical (taint dataflow analyzer).

| | errors | files with errors |
|---|---|---|
| post-#296 baseline | 905 | 214 |
| after | 889 | 213 |
| delta | **-16** | **-1** |

## Three underlying issues

1. **9 sites × shadowed-loop-var idiom.** Each language-specific pairing pass (`paired = []` for Python, C, C++, JS, TS, Java, Rust, Go) reuses the loop variable `node` from the immediately-preceding `for node in stack:` block. mypy carries the prior `Node` type into the new scope, so the `node = node_by_line.get(...)`'s `Node | None` doesn't fit. Rename the inner-loop binding to `matched_node` at each site (and the related C++ block's `else: unpaired_units.append(unit)` becomes reachable again automatically).

2. **`inner` redefined with a different type at line 8815 / 8862.** The `cast_expression` branch defines `inner = expr.child_by_field_name(...)` (`Node | None`); the `method_invocation` sanitizer branch later defines `inner: Optional[_JavaTaint] = None`. mypy's `no-redef` rule flags the second one, which then cascades into 4 more errors at lines 8876, 8889, 8891, 8893 where the sanitizer code treats `inner` as `_JavaTaint`. Rename the `cast_expression` local to `cast_inner`.

3. **Dead code: `if cursor is None: return None` after the while loop at 5547-5548.** The preceding while loop body assigns `cursor = left` only after `if left is None: return None`, so at loop exit `cursor` is provably non-None and the check is unreachable. Remove.

## Test plan

- [ ] CI green
- [ ] After merge, CI mypy count drops by ~16

## Sweep totals (this session)

| PR | File | errors |
|---|---|---|
| #295 | `identity/providers/saml_provider.py` | -13 |
| #296 | `airgap/edge_runtime.py` | -17 |
| #297 (this) | `vulnerability_scanner/parsing/dataflow.py` | -16 |
| **Total** | **3 files** | **-46** |