### PR TITLE
fix(mypy): clear 5 type errors in airgap/air_gap_orchestrator.py

### DIFF
--- a/src/services/airgap/air_gap_orchestrator.py
+++ b/src/services/airgap/air_gap_orchestrator.py
@@ -16,7 +16,7 @@ import tarfile
 import tempfile
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from .config import AirGapConfig, get_airgap_config
 from .contracts import (
@@ -102,12 +102,15 @@ class AirGapOrchestrator:
     ) -> str:
         """Compute hash of a file."""
         if algorithm == HashAlgorithm.SHA256:
-            hasher = hashlib.sha256()
+            hasher: Any = hashlib.sha256()
         elif algorithm == HashAlgorithm.SHA384:
             hasher = hashlib.sha384()
         elif algorithm == HashAlgorithm.SHA512:
             hasher = hashlib.sha512()
         elif algorithm == HashAlgorithm.BLAKE2B:
+            # blake2b is a distinct class in the hashlib stubs, not a HASH
+            # subclass, so the loose `Any` annotation above is required to
+            # let the variable hold either branch's return type.
             hasher = hashlib.blake2b()
         else:
             hasher = hashlib.sha256()
@@ -115,7 +118,8 @@ class AirGapOrchestrator:
         with open(file_path, "rb") as f:
             for chunk in iter(lambda: f.read(8192), b""):
                 hasher.update(chunk)
-        return hasher.hexdigest()
+        digest: str = hasher.hexdigest()
+        return digest
 
     def _get_compression_extension(self, compression: CompressionType) -> str:
         """Get file extension for compression type."""
@@ -128,9 +132,11 @@ class AirGapOrchestrator:
         }
         return extensions.get(compression, ".tar.gz")
 
-    def _get_tarfile_mode(self, compression: CompressionType) -> str:
+    def _get_tarfile_mode(
+        self, compression: CompressionType
+    ) -> Literal["w", "w:gz", "w:xz"]:
         """Get tarfile mode for compression type."""
-        modes = {
+        modes: dict[CompressionType, Literal["w", "w:gz", "w:xz"]] = {
             CompressionType.NONE: "w",
             CompressionType.GZIP: "w:gz",
             CompressionType.XZ: "w:xz",
@@ -328,15 +334,19 @@ class AirGapOrchestrator:
                 Ed25519PrivateKey,
             )
 
-            private_key = Ed25519PrivateKey.generate()
-            public_key = private_key.public_key()
+            # Rename: the earlier `private_key = os.urandom(64)` branch
+            # bound `private_key` to bytes, so mypy can't accept the
+            # Ed25519PrivateKey object here. Use distinct names; the
+            # function returns `(bytes, bytes)` either way.
+            ed_private = Ed25519PrivateKey.generate()
+            ed_public = ed_private.public_key()
 
-            private_bytes = private_key.private_bytes(
+            private_bytes = ed_private.private_bytes(
                 encoding=serialization.Encoding.Raw,
                 format=serialization.PrivateFormat.Raw,
                 encryption_algorithm=serialization.NoEncryption(),
             )
-            public_bytes = public_key.public_bytes(
+            public_bytes = ed_public.public_bytes(
                 encoding=serialization.Encoding.Raw,
                 format=serialization.PublicFormat.Raw,
             )


### PR DESCRIPTION
Fifth file in the mypy debt sweep (after #295 / #296 / #297 / #298).

| | errors | files with errors |
|---|---|---|
| post-#297 baseline | 889 | 213 |
| after | 884 | 212 |
| delta | **-5** | **-1** |

(Per-file count had flagged 19 errors here in the whole-tree mypy run; in-isolation mypy on just this file showed 5. The other 14 were cross-file effects that resolve when the 5 local errors clear — net `-5` on the global total.)

## Three underlying issues

1. **`hasher` branch-type join (line 111).** The `_compute_hash` chain assigns `hasher = hashlib.sha256()` (returns `HASH`) in three branches and `hasher = hashlib.blake2b()` (returns the separate `blake2b` class per the stubs) in the fourth. Mypy's join of those branch types fails. Annotate the first assignment as `Any` and explicitly bind the final `.hexdigest()` to a `str` so the function's `-> str` return is preserved.

2. **`tarfile.open(name, mode)` overload mismatch (line 267).** `_get_tarfile_mode` returned `str` but `tarfile.open` overloads are keyed on `Literal["w", "w:gz", "w:xz", ...]`, so mypy couldn't pick a variant. Tighten the return type and the internal lookup dict to `Literal["w", "w:gz", "w:xz"]` (the actual value set).

3. **`private_key` reused for two distinct types (line 331).** The mock-keys branch binds `private_key = os.urandom(64)` (bytes); the real-crypto branch later binds `private_key = Ed25519PrivateKey.generate()`. Mypy carries `bytes` from the first branch and rejects the second + the cascading `.public_key()` / `.private_bytes(...)` calls. Rename the second-branch local to `ed_private` (+ `ed_public`). Function returns `(bytes, bytes)` either way.

## Sweep totals (5 PRs, this session)

| PR | File | errors |
|---|---|---|
| #295 | `identity/providers/saml_provider.py` | -13 |
| #296 | `airgap/edge_runtime.py` | -17 |
| #297 | `vulnerability_scanner/parsing/dataflow.py` | -16 |
| #298 | `dashboard/dashboard_service.py` + `models.py` | -25 |
| #299 (this) | `airgap/air_gap_orchestrator.py` | -5 |
| **Total** | **6 files** | **-76** |