### PR TITLE
fix(mypy): correct test_results dict-value type in ssr/validation_pipeline.py

### DIFF
--- a/src/services/ssr/validation_pipeline.py
+++ b/src/services/ssr/validation_pipeline.py
@@ -51,7 +51,7 @@ class SandboxExecutionResult:
     stdout: str
     stderr: str
     duration_seconds: float
-    test_results: dict[str, str] = field(default_factory=dict)
+    test_results: dict[str, int] = field(default_factory=dict)
 
 
 class ValidationPipeline:


### PR DESCRIPTION
Sixth file in the mypy debt sweep, after #295–#299.

| | errors | files with errors |
|---|---|---|
| post-#299 baseline | 859 | 210 |
| after | 846 | 209 |
| delta | **-13** | **-1** |

## Single root-cause fix

`SandboxExecutionResult.test_results` was annotated `dict[str, str]` but **every** producer and consumer treats the values as test counts (`int`):

- Constructed as `{"passed": 10, "failed": 0}` (lines 483, 616, 686)
- Compared as `passing < self.min_passing_tests` (lines 487, 620, 693)
- Summed as `passing + exec_result.test_results.get("failed", 0)` (lines 494, 505)

Change the annotation to `dict[str, int]` so it matches actual usage. One-line diff in `validation_pipeline.py`'s dataclass.

## Sweep totals (6 PRs, this session)

| PR | File | errors |
|---|---|---|
| #295 | `identity/providers/saml_provider.py` | -13 |
| #296 | `airgap/edge_runtime.py` | -17 |
| #297 | `vulnerability_scanner/parsing/dataflow.py` | -16 |
| #298 | `dashboard/dashboard_service.py` + `models.py` | -25 |
| #299 | `airgap/air_gap_orchestrator.py` | -5 |
| #300 (this) | `ssr/validation_pipeline.py` | -13 |
| **Total** | **7 files** | **-89** |