### PR TITLE
fix(ci): stop aura-webhook runs cancelling each other on main

### DIFF
--- a/.github/workflows/aura-webhook.yml
+++ b/.github/workflows/aura-webhook.yml
@@ -26,10 +26,13 @@ on:
           - force_ingestion
           - health_check
 
-# Cancel in-progress runs when new commits are pushed
+# This workflow delivers each push/PR/release as a webhook to the Aura platform,
+# so runs must NOT cancel one another -- a cancelled run is a dropped delivery.
+# Group per-commit (not per-ref) so rapid pushes to the same branch each deliver
+# independently instead of a newer run cancelling the in-flight one.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

The **Aura Webhook Integration** workflow was failing on `main` with:

> Canceling since a higher priority waiting request for Aura Webhook Integration-refs/heads/main exists

Its `concurrency` group was keyed by **ref** with `cancel-in-progress: true`:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}
cancel-in-progress: true
```

So when commits land on `main` in quick succession, each new run cancels the in-flight one. For a **webhook notifier** that's not just noise — a cancelled run is a **dropped delivery**: that commit's push event never reaches the Aura platform (`/webhook/github`, `/api/v1/ingest`).

## Fix

Group **per-commit** and disable cancellation so every push/PR/release delivers independently:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
cancel-in-progress: false
```

- Adding `github.sha` means distinct commits no longer share a group, so a newer push can't cancel an in-flight one.
- `cancel-in-progress: false` makes a true duplicate (same commit re-triggered) queue instead of cancel.

Cost is negligible — each run is a lightweight `curl`, and the notification steps already use `continue-on-error: true`.