### PR TITLE
fix(cfn): bump deprecated python3.11 Lambda runtimes to python3.12

### DIFF
--- a/deploy/cloudformation/aura-cost-alerts.yaml
+++ b/deploy/cloudformation/aura-cost-alerts.yaml
@@ -246,7 +246,7 @@ Resources:
     Properties:
       FunctionName: !Sub 'aura-calculate-threshold-${Environment}'
       Description: Calculates budget threshold percentages for AWS cost alert notifications
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt CalculateThresholdRole.Arn
       Code:
@@ -369,7 +369,7 @@ Resources:
     Condition: EnableEnforcement
     Properties:
       FunctionName: !Sub 'aura-budget-enforcement-${Environment}'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt BudgetEnforcementRole.Arn
       Environment:

--- a/deploy/cloudformation/calibration-pipeline.yaml
+++ b/deploy/cloudformation/calibration-pipeline.yaml
@@ -202,7 +202,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-calibration-pipeline-${Environment}'
       Description: 'Nightly calibration training for documentation confidence scores'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt CalibrationLambdaRole.Arn
       Timeout: 900

--- a/deploy/cloudformation/chat-assistant.yaml
+++ b/deploy/cloudformation/chat-assistant.yaml
@@ -382,7 +382,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-chat-handler-${Environment}'
       Description: Processes chat messages via Bedrock Claude with tool use
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: chat_handler.handler
       Role: !GetAtt ChatLambdaRole.Arn
       MemorySize: !Ref LambdaMemorySize
@@ -420,7 +420,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-chat-ws-connect-${Environment}'
       Description: Handles WebSocket connection establishment
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: ws_connect.handler
       Role: !GetAtt ChatLambdaRole.Arn
       MemorySize: 256
@@ -446,7 +446,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-chat-ws-disconnect-${Environment}'
       Description: Handles WebSocket disconnection cleanup
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: ws_disconnect.handler
       Role: !GetAtt ChatLambdaRole.Arn
       MemorySize: 256
@@ -472,7 +472,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-chat-ws-message-${Environment}'
       Description: Handles incoming WebSocket messages for streaming
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: ws_message.handler
       Role: !GetAtt ChatLambdaRole.Arn
       MemorySize: !Ref LambdaMemorySize

--- a/deploy/cloudformation/compliance-settings-sync.yaml
+++ b/deploy/cloudformation/compliance-settings-sync.yaml
@@ -110,7 +110,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-compliance-settings-sync-${Environment}'
       Description: 'Syncs compliance settings to SSM Parameter Store for CodeBuild'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: compliance_settings_sync.handler
       Role: !GetAtt ComplianceSyncLambdaRole.Arn
       MemorySize: 256

--- a/deploy/cloudformation/constitutional-ai-evaluation.yaml
+++ b/deploy/cloudformation/constitutional-ai-evaluation.yaml
@@ -260,7 +260,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-cai-evaluation-${Environment}'
       Description: Nightly Constitutional AI evaluation - LLM-as-Judge, golden set regression
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: src.lambda.constitutional_evaluation.handler.handler
       Role: !GetAtt EvaluationLambdaRole.Arn
       MemorySize: !Ref LambdaMemorySize

--- a/deploy/cloudformation/constitutional-audit-queue.yaml
+++ b/deploy/cloudformation/constitutional-audit-queue.yaml
@@ -203,7 +203,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-constitutional-audit-consumer-${Environment}'
       Description: Constitutional AI audit queue consumer (ADR-063 Phase 3)
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: src.lambda.constitutional_audit.handler.lambda_handler
       Role: !GetAtt AuditConsumerLambdaRole.Arn
       Code:

--- a/deploy/cloudformation/dashboard-dynamodb.yaml
+++ b/deploy/cloudformation/dashboard-dynamodb.yaml
@@ -105,7 +105,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub '${ProjectName}-dashboard-audit-stream-${Environment}'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Timeout: 30
       MemorySize: 128

--- a/deploy/cloudformation/deployment-pipeline.yaml
+++ b/deploy/cloudformation/deployment-pipeline.yaml
@@ -219,7 +219,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-codebuild-poller-${Environment}'
       Description: Polls CodeBuild build status for Step Functions orchestration
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 30
@@ -283,7 +283,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-k8s-config-generator-${Environment}'
       Description: Generates Kubernetes configuration files for environment deployment
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 300
@@ -380,7 +380,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-k8s-deployer-${Environment}'
       Description: Checks Kubernetes deployment status for Step Functions orchestration
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 60

--- a/deploy/cloudformation/dev-cost-scheduler.yaml
+++ b/deploy/cloudformation/dev-cost-scheduler.yaml
@@ -212,7 +212,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-dev-cost-scaler-${Environment}'
       Description: Scales all DEV EKS nodegroups for off-hours cost optimization
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt DevScalerRole.Arn
       Timeout: 900  # 15 min, Lambda max -- accommodates per-nodegroup polling (#186 H4)

--- a/deploy/cloudformation/dns-blocklist-lambda.yaml
+++ b/deploy/cloudformation/dns-blocklist-lambda.yaml
@@ -153,7 +153,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-blocklist-updater-${Environment}'
       Description: 'Generates DNS blocklists from threat intelligence feeds'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.lambda_handler
       Role: !GetAtt BlocklistLambdaRole.Arn
       Timeout: 300

--- a/deploy/cloudformation/drift-detection.yaml
+++ b/deploy/cloudformation/drift-detection.yaml
@@ -208,7 +208,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-drift-detector-${Environment}'
       Description: !Sub 'Detects CloudFormation drift for ${ProjectName} stacks in ${Environment}'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.lambda_handler
       Role: !GetAtt DriftDetectorLambdaRole.Arn
       Timeout: !Ref LambdaTimeout

--- a/deploy/cloudformation/env-validator-drift-lambda.yaml
+++ b/deploy/cloudformation/env-validator-drift-lambda.yaml
@@ -112,7 +112,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-env-drift-detector-${Environment}'
       Description: Scheduled drift detection for environment validator (ADR-062)
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: src.services.env_validator.lambda_handler.lambda_handler
       Role: !GetAtt DriftLambdaRole.Arn
       Code:

--- a/deploy/cloudformation/hitl-callback.yaml
+++ b/deploy/cloudformation/hitl-callback.yaml
@@ -146,7 +146,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${ProjectName}-approval-callback-${Environment}
       Description: Processes approval decisions and sends Step Functions callbacks
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: src.lambda.approval_callback_handler.handler
       Role: !GetAtt ApprovalCallbackRole.Arn
       MemorySize: !Ref LambdaMemorySize

--- a/deploy/cloudformation/hitl-scheduler.yaml
+++ b/deploy/cloudformation/hitl-scheduler.yaml
@@ -155,7 +155,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${ProjectName}-expiration-processor-${Environment}
       Description: Processes expired HITL approval requests with auto-escalation
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: src.lambda.expiration_processor.handler
       Role: !GetAtt ExpirationProcessorRole.Arn
       MemorySize: !Ref LambdaMemorySize

--- a/deploy/cloudformation/incident-response.yaml
+++ b/deploy/cloudformation/incident-response.yaml
@@ -247,7 +247,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-deployment-recorder-${Environment}'
       Description: Records ArgoCD deployment events to DynamoDB
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.lambda_handler
       Role: !GetAtt DeploymentRecorderRole.Arn
       Timeout: 30

--- a/deploy/cloudformation/log-retention-sync.yaml
+++ b/deploy/cloudformation/log-retention-sync.yaml
@@ -118,7 +118,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-log-retention-sync-${Environment}'
       Description: 'Syncs CloudWatch log retention policies based on UI settings'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.lambda_handler
       Role: !GetAtt LogRetentionLambdaRole.Arn
       Timeout: 300

--- a/deploy/cloudformation/orchestrator-dispatcher.yaml
+++ b/deploy/cloudformation/orchestrator-dispatcher.yaml
@@ -127,7 +127,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-orchestrator-dispatcher-${Environment}'
       Description: Dispatches SQS messages to EKS MetaOrchestrator Jobs
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: orchestrator_dispatcher.lambda_handler
       Role: !GetAtt OrchestratorDispatcherRole.Arn
       Timeout: 30

--- a/deploy/cloudformation/org-cost-monitoring.yaml
+++ b/deploy/cloudformation/org-cost-monitoring.yaml
@@ -418,7 +418,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-cost-aggregator-${Environment}'
       Description: Aggregates costs across accounts and services for organization-level tracking
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt CostAggregatorRole.Arn
       Timeout: 300
@@ -789,7 +789,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-threshold-calc-${Environment}'
       Description: Calculates service-specific budget thresholds
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt ThresholdCalculatorRole.Arn
       Code:

--- a/deploy/cloudformation/qa-cost-scheduler.yaml
+++ b/deploy/cloudformation/qa-cost-scheduler.yaml
@@ -173,7 +173,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-qa-scaler-${Environment}'
       Description: Scales QA EKS nodegroup for cost optimization
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt QAScalerRole.Arn
       Timeout: 600  # 10 min -- accommodates EKS nodegroup scale-completion polling (#186 H4)

--- a/deploy/cloudformation/realtime-monitoring.yaml
+++ b/deploy/cloudformation/realtime-monitoring.yaml
@@ -284,7 +284,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-orchestrator-trigger-${Environment}'
       Description: Triggers MetaOrchestrator for autonomous remediation of critical security events
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.lambda_handler
       Role: !GetAtt OrchestratorTriggerRole.Arn
       Timeout: 60

--- a/deploy/cloudformation/runtime-security-discovery.yaml
+++ b/deploy/cloudformation/runtime-security-discovery.yaml
@@ -210,7 +210,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-ghost-agent-scanner-${Environment}'
       Description: Weekly ghost agent scanner for decommission assurance (ADR-086)
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: !If
         - HasLambdaPackage
         - ghost_agent_scanner.lambda_handler

--- a/deploy/cloudformation/scheduling-infrastructure.yaml
+++ b/deploy/cloudformation/scheduling-infrastructure.yaml
@@ -226,7 +226,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-scheduler-dispatcher-${Environment}'
       Description: Dispatches due scheduled jobs to the orchestration queue
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !GetAtt SchedulerDispatcherRole.Arn
       Timeout: 60

--- a/deploy/cloudformation/test-env-approval.yaml
+++ b/deploy/cloudformation/test-env-approval.yaml
@@ -63,7 +63,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-test-env-request-approval-${Environment}'
       Description: 'Sends HITL approval request for test environment provisioning'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !Ref StepFunctionsRoleArn
       Timeout: 30
@@ -152,7 +152,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-test-env-process-approval-${Environment}'
       Description: 'Processes HITL approval decision for test environment'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !Ref StepFunctionsRoleArn
       Timeout: 30
@@ -230,7 +230,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-test-env-provision-${Environment}'
       Description: 'Provisions approved test environment via Service Catalog'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !Ref StepFunctionsRoleArn
       Timeout: 300
@@ -325,7 +325,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-test-env-handle-timeout-${Environment}'
       Description: 'Handles approval timeout for test environment requests'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Role: !Ref StepFunctionsRoleArn
       Timeout: 30

--- a/deploy/cloudformation/test-env-budgets.yaml
+++ b/deploy/cloudformation/test-env-budgets.yaml
@@ -216,7 +216,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-test-env-cost-aggregator-${Environment}'
       Description: Aggregates test environment costs and publishes to CloudWatch
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.handler
       Timeout: 60
       MemorySize: 256

--- a/deploy/cloudformation/test-env-marketplace.yaml
+++ b/deploy/cloudformation/test-env-marketplace.yaml
@@ -153,7 +153,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-test-env-marketplace-submit-${Environment}'
       Description: 'Handles user template submissions to the marketplace'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: marketplace_handler.submit_handler
       Role: !Ref MarketplaceRoleArn
       MemorySize: 256
@@ -207,7 +207,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-test-env-marketplace-approve-${Environment}'
       Description: 'Handles admin approval/rejection of marketplace templates'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: marketplace_handler.approve_handler
       Role: !Ref MarketplaceRoleArn
       MemorySize: 256

--- a/deploy/cloudformation/test-env-namespace.yaml
+++ b/deploy/cloudformation/test-env-namespace.yaml
@@ -97,7 +97,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-test-env-namespace-controller-${Environment}'
       Description: 'Manages EKS namespaces for quick test environments'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: namespace_controller.handler
       Role: !Ref NamespaceControllerRoleArn
       MemorySize: 512

--- a/deploy/cloudformation/test-env-scheduler.yaml
+++ b/deploy/cloudformation/test-env-scheduler.yaml
@@ -155,7 +155,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-test-env-scheduler-processor-${Environment}'
       Description: 'Processes scheduled test environment provisioning requests'
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: scheduled_provisioner.handler
       Role: !Ref SchedulerRoleArn
       MemorySize: 256

--- a/deploy/cloudformation/threat-intel-scheduler.yaml
+++ b/deploy/cloudformation/threat-intel-scheduler.yaml
@@ -167,7 +167,7 @@ Resources:
     Properties:
       FunctionName: !Sub ${ProjectName}-threat-intel-processor-${Environment}
       Description: Daily threat intelligence pipeline - gathers CVE/CISA/GitHub advisories
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: src.lambda.threat_intelligence_processor.handler
       Role: !GetAtt ThreatIntelProcessorRole.Arn
       MemorySize: !Ref LambdaMemorySize

--- a/deploy/cloudformation/vuln-scan-cleanup.yaml
+++ b/deploy/cloudformation/vuln-scan-cleanup.yaml
@@ -45,7 +45,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${ProjectName}-vuln-scan-cleanup-${Environment}'
       Description: Scheduled cleanup for expired scan artifacts and orphaned state
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: index.lambda_handler
       Role: !ImportValue
         Fn::Sub: '${ProjectName}-vuln-scan-cleanup-role-arn-${Environment}'


### PR DESCRIPTION
## Problem

`cfn-lint` **W2531**: the `python3.11` Lambda runtime was deprecated on **2026-06-30** (creation disabled 2026-07-31, update 2026-08-31). This started failing CloudFormation template validation — e.g. `test_threat_intelligence_processor.py::TestCloudFormationTemplate::test_template_is_valid_cloudformation`.

## Fix

Bump all **40** `Runtime: python3.11` declarations across **29 templates** to `python3.12`.

- `python3.12` is already the runtime used by the other **15 templates** in `deploy/cloudformation/`, so this introduces no new convention (chose it over the notice's suggested 3.14 to minimize compat surface).
- The diff is **only** `Runtime:` lines — no other template changes.

## Verification

- `cfn-lint` clears W2531 on the touched templates; the previously-failing CloudFormation validation test now passes.
- No `python3.11` runtime declarations remain in `deploy/cloudformation/`.