### PR TITLE
ci: bump codeql-action to 4.36.3 (init/autobuild/analyze, lockstep)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,16 +37,16 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: ${{ matrix.language }}
           config-file: .github/codeql/codeql-config.yml
           queries: +security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Bumps `github/codeql-action/init`, `/autobuild`, and `/analyze` to **4.36.3** (`54f647b`), matching `upload-sarif` which was already updated to 4.36.3 in #308.

### Why one PR instead of the individual Dependabot PRs
Dependabot opened #306, #307, #309 to bump these three sub-actions separately. Each fails the `Analyze` jobs on its own because the `github/codeql-action/*` sub-actions must run at the **same version** — bumping only one leaves an init/autobuild/analyze version mismatch. Consolidating all three into a single commit keeps them in lockstep and matches the already-merged `upload-sarif` (#308).

Supersedes #306, #307, #309.