### PR TITLE
ci(dependabot): ignore tree-sitter >=0.26 until timeout API is restored

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,17 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # tree-sitter 0.26+ removed parser.timeout_micros — the parse-time bound
+      # used as a DoS guard on untrusted input in
+      # src/services/vulnerability_scanner/parsing/ast.py. 0.26 offers no working
+      # replacement (progress_callback is ignored for bytestrings and segfaults
+      # with a reader source; verified 2026-07-01). Deliberate hold — see
+      # docs/DEFERRED_WORK_REGISTRY.md ("tree-sitter 0.26+ migration") and
+      # requirements.txt:22. Re-evaluated quarterly; reinforced until upstream
+      # ships a working bytestring parse-timeout API.
+      - dependency-name: "tree-sitter"
+        versions: [">=0.26"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Adds a Dependabot `ignore` rule so it stops re-proposing `tree-sitter >=0.26` every week (most recently #320, now closed).

### Why
`tree-sitter` 0.26.0 removed `parser.timeout_micros`, the parse-time bound used as a **DoS guard on untrusted input** in `src/services/vulnerability_scanner/parsing/ast.py` (`ParsingConfig.tree_sitter_timeout_ms=5000`). 0.26 has **no working replacement**: `progress_callback` is silently ignored for bytestring sources and **segfaults** with a reader source (verified 2026-07-01). This is a documented, deliberate hold — see `docs/DEFERRED_WORK_REGISTRY.md` ("tree-sitter 0.26+ migration") and `requirements.txt:22`.

### Governance
The rule is **re-evaluated quarterly** (a scheduled check watches py-tree-sitter releases for a fixed 0.26.x that restores a working bytestring parse timeout). If a fix is available, the migration is unblocked and this rule is lifted; if not, the hold is **reinforced** until the next review.

Closes the loop on #320.