### PR TITLE
ci: bump github/codeql-action to 4.37.1 across all sub-actions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -277,7 +277,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         if: always()
         continue-on-error: true  # GitHub Advanced Security may not be enabled
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,16 +37,16 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: ${{ matrix.language }}
           config-file: .github/codeql/codeql-config.yml
           queries: +security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
Bumps all four `github/codeql-action/*` steps (init, autobuild, analyze, upload-sarif) to **v4.37.1** (`7188fc3`) in a single change.

## Why one PR
CodeQL requires every workflow step that uses the action to be on the **same version**. Dependabot split the bump into four separate PRs (#351 init, #352 upload-sarif, #353 autobuild, #354 analyze); merging any subset leaves `main` version-mismatched and CodeQL fails with:

```
Loaded a configuration file for version '4.37.1', but running version '4.36.3'
```

## Closes
Supersedes the split Dependabot PRs: closes #351, #352, #353, #354.

## Files
- `.github/workflows/codeql.yml` — init, autobuild, analyze
- `.github/workflows/code-quality.yml` — upload-sarif