### PR TITLE
fix(ingestion): bind concurrency semaphores to the running event loop

### DIFF
--- a/src/services/git_ingestion_service.py
+++ b/src/services/git_ingestion_service.py
@@ -228,22 +228,34 @@ class GitIngestionService:
         )
 
         # Concurrency limits for thread pool operations
-        # These prevent spawning too many threads during large ingestion jobs
-        self._parse_semaphore = asyncio.Semaphore(
+        # These prevent spawning too many threads during large ingestion jobs.
+        # Semaphores are created lazily and bound to the running event loop the
+        # first time they are used (see ``_loop_bound_semaphore``): an
+        # ``asyncio.Semaphore`` binds to the loop it is first awaited on, so a
+        # single long-lived service instance reused across event loops (e.g.
+        # repeated ``asyncio.run`` calls) would otherwise raise "bound to a
+        # different event loop".
+        self._max_concurrent_parse = (
             max_concurrent_parse
             if max_concurrent_parse is not None
             else self.DEFAULT_MAX_CONCURRENT_PARSE
         )
-        self._graph_semaphore = asyncio.Semaphore(
+        self._max_concurrent_graph = (
             max_concurrent_graph
             if max_concurrent_graph is not None
             else self.DEFAULT_MAX_CONCURRENT_GRAPH
         )
-        self._index_semaphore = asyncio.Semaphore(
+        self._max_concurrent_index = (
             max_concurrent_index
             if max_concurrent_index is not None
             else self.DEFAULT_MAX_CONCURRENT_INDEX
         )
+        # Cache of (event loop, semaphore) per logical name. Rebuilt when the
+        # running loop changes so concurrency limiting stays correct without
+        # leaking a semaphore bound to a closed loop.
+        self._semaphores: dict[
+            str, tuple[asyncio.AbstractEventLoop, asyncio.Semaphore]
+        ] = {}
 
         # OpenSearch bulk indexing configuration
         self.opensearch_bulk_size = (
@@ -905,9 +917,26 @@ class GitIngestionService:
             entities = self.ast_parser.parse_file(file_path)
             return list(entities), []
 
+    def _loop_bound_semaphore(self, name: str, limit: int) -> asyncio.Semaphore:
+        """Return a semaphore bound to the currently running event loop.
+
+        ``asyncio.Semaphore`` binds to the loop it is first used on. A single
+        service instance can outlive an event loop (repeated ``asyncio.run``
+        in benchmarks, worker restarts), so we cache one semaphore per loop and
+        rebuild it when the running loop changes. All coroutines sharing a loop
+        get the same instance, preserving the concurrency limit.
+        """
+        loop = asyncio.get_running_loop()
+        cached = self._semaphores.get(name)
+        if cached is None or cached[0] is not loop:
+            semaphore = asyncio.Semaphore(limit)
+            self._semaphores[name] = (loop, semaphore)
+            return semaphore
+        return cached[1]
+
     async def _parse_file_with_limit(self, file_path: Path, repo_path: Path) -> tuple:
         """Parse a single file with concurrency limiting."""
-        async with self._parse_semaphore:
+        async with self._loop_bound_semaphore("parse", self._max_concurrent_parse):
             return await asyncio.to_thread(
                 self._parse_single_file, file_path, repo_path
             )
@@ -1024,7 +1053,7 @@ class GitIngestionService:
         fqn_builder: FQNBuilder | None = None,
     ) -> None:
         """Add entity to graph with concurrency limiting."""
-        async with self._graph_semaphore:
+        async with self._loop_bound_semaphore("graph", self._max_concurrent_graph):
             await asyncio.to_thread(
                 self._add_entity_to_graph, entity, repo_id, branch, fqn_builder
             )
@@ -1066,7 +1095,7 @@ class GitIngestionService:
         self, relationship, repo_id: str, branch: str
     ) -> None:
         """Add relationship to graph with concurrency limiting."""
-        async with self._graph_semaphore:
+        async with self._loop_bound_semaphore("graph", self._max_concurrent_graph):
             await asyncio.to_thread(
                 self._add_relationship_to_graph, relationship, repo_id, branch
             )
@@ -1212,7 +1241,7 @@ class GitIngestionService:
 
         Offloads blocking Neptune calls to thread pool to avoid blocking
         the event loop. Entities are processed concurrently with limited
-        parallelism controlled by _graph_semaphore.
+        parallelism controlled by the loop-bound "graph" semaphore.
 
         When upsert=True (incremental re-ingest), outgoing edges of every
         entity in each affected file are deleted before new edges are
@@ -1493,7 +1522,7 @@ class GitIngestionService:
 
         Returns a document dict ready for bulk_index_embeddings, or None if preparation fails.
         """
-        async with self._index_semaphore:
+        async with self._loop_bound_semaphore("index", self._max_concurrent_index):
             try:
                 # Offload blocking file read to thread
                 content = await asyncio.to_thread(self._read_file_content, file_path)

--- a/tests/test_git_ingestion_service.py
+++ b/tests/test_git_ingestion_service.py
@@ -1345,30 +1345,58 @@ class TestAsyncConcurrency:
                 max_concurrent_index=1,
             )
 
-    def test_semaphore_initialization(self, service_with_concurrency):
-        """Test that semaphores are initialized with correct limits."""
+    def test_semaphore_limits_stored(self, service_with_concurrency):
+        """Concurrency limits are stored eagerly; semaphores are lazy.
+
+        Semaphores bind to the running event loop on first use, so they are
+        created on demand by ``_loop_bound_semaphore`` rather than in
+        ``__init__`` -- only the integer limits are stored up front.
+        """
         service = service_with_concurrency
-        # Semaphores should be created
-        assert hasattr(service, "_parse_semaphore")
-        assert hasattr(service, "_graph_semaphore")
-        assert hasattr(service, "_index_semaphore")
-        # Semaphores are asyncio.Semaphore instances
-        assert isinstance(service._parse_semaphore, asyncio.Semaphore)
-        assert isinstance(service._graph_semaphore, asyncio.Semaphore)
-        assert isinstance(service._index_semaphore, asyncio.Semaphore)
+        assert service._max_concurrent_parse == 2
+        assert service._max_concurrent_graph == 3
+        assert service._max_concurrent_index == 1
+        # No eager semaphores cached until a coroutine uses one.
+        assert service._semaphores == {}
 
     def test_default_concurrency_limits(self, service):
         """Test that default concurrency limits are applied."""
-        assert service._parse_semaphore._value == 10  # DEFAULT_MAX_CONCURRENT_PARSE
-        assert service._graph_semaphore._value == 20  # DEFAULT_MAX_CONCURRENT_GRAPH
-        assert service._index_semaphore._value == 5  # DEFAULT_MAX_CONCURRENT_INDEX
+        assert service._max_concurrent_parse == 10  # DEFAULT_MAX_CONCURRENT_PARSE
+        assert service._max_concurrent_graph == 20  # DEFAULT_MAX_CONCURRENT_GRAPH
+        assert service._max_concurrent_index == 5  # DEFAULT_MAX_CONCURRENT_INDEX
 
-    def test_custom_concurrency_limits(self, service_with_concurrency):
-        """Test that custom concurrency limits are applied."""
+    @pytest.mark.asyncio
+    async def test_loop_bound_semaphore_is_stable_within_loop(
+        self, service_with_concurrency
+    ):
+        """The same loop yields the same semaphore, sized to the limit."""
         service = service_with_concurrency
-        assert service._parse_semaphore._value == 2
-        assert service._graph_semaphore._value == 3
-        assert service._index_semaphore._value == 1
+        sem = service._loop_bound_semaphore("parse", service._max_concurrent_parse)
+        assert isinstance(sem, asyncio.Semaphore)
+        assert sem._value == 2
+        # Repeated calls within the same loop return the identical instance so
+        # the concurrency limit is actually shared across coroutines.
+        assert service._loop_bound_semaphore("parse", 2) is sem
+
+    def test_loop_bound_semaphore_rebinds_across_loops(self, service_with_concurrency):
+        """A reused service instance rebinds semaphores per event loop.
+
+        Regression guard: a single ``asyncio.Semaphore`` binds to the loop it
+        is first awaited on, so reusing one service across ``asyncio.run``
+        calls previously raised "bound to a different event loop".
+        """
+        service = service_with_concurrency
+
+        async def _grab():
+            sem = service._loop_bound_semaphore("parse", 2)
+            async with sem:
+                return sem
+
+        first = asyncio.run(_grab())
+        second = asyncio.run(_grab())
+        # Different loops -> different semaphore instances, and acquiring in the
+        # second loop must not raise the cross-loop RuntimeError.
+        assert first is not second
 
     @pytest.mark.asyncio
     async def test_discover_files_is_async(self, service):


### PR DESCRIPTION
## Problem
`GitIngestionService` created its `parse`/`graph`/`index` `asyncio.Semaphore`s eagerly in `__init__`. An `asyncio.Semaphore` binds to the event loop it is **first awaited on**. A single service instance reused across event loops — the ADR-090 benchmark calls `asyncio.run()` once per warmup/measured run (8 loops per test) against one fixture-scoped service — fails on every loop after the first with:

```
Parse task failed: <asyncio.locks.Semaphore ...> is bound to a different event loop
```

Every parse task raised, silently corrupting the benchmark: throughput collapsed to ~2000 edges/sec against the 4000 gate, failing `test_ingestion_throughput_within_threshold`. This blocked unrelated Dependabot PRs (#355, #338) whose only red check was this benchmark.

It is also a latent production bug: any service instance that outlives its event loop (worker loop torn down/recreated) hits the same error.

## Fix
Store the limits as ints and create each semaphore lazily via `_loop_bound_semaphore`, caching one per running loop and rebuilding when the loop changes. Coroutines sharing a loop still share a semaphore, so the concurrency limit is preserved.

## Verification
- `tests/performance/test_ingestion_benchmarks.py` — all 3 pass; no cross-loop warnings (throughput back over the 4000 gate; was ~2000).
- `tests/test_git_ingestion_service.py` — 77 pass, including a new regression test that reuses one service across two `asyncio.run` calls.

## Follow-up
Once merged, #355 and #338 can be rebased and should go green.