### PR TITLE
ci: bump github/codeql-action/init to 4.37.3 for lockstep consistency

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
           config-file: .github/codeql/codeql-config.yml


### PR DESCRIPTION
The 4.37.3 dependabot round only opened PRs for `analyze`, `autobuild`, and `upload-sarif` (#361, #362, #363). `init` was left pinned at 4.37.1, producing `Loaded a configuration file for version '4.37.1', but running version '4.37.3'` and failing every Analyze job on main and all open PRs.

This bumps `init` to the same 4.37.3 SHA (`e4fba868`) as the other sub-actions, restoring lockstep consistency.